### PR TITLE
tests: fix cloner function

### DIFF
--- a/t/func/framework/utils.py
+++ b/t/func/framework/utils.py
@@ -1,13 +1,15 @@
 # SPDX-FileCopyrightText: (c) 2026 Tempesta Technologies, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+from __future__ import annotations
+
 import asyncio
 import dataclasses
 import enum
 import functools
 import logging
 from contextlib import asynccontextmanager
-from typing import Callable, TypeVar, Union
+from typing import TYPE_CHECKING, Callable, Optional, Protocol, Type, Union
 
 import backoff
 from scapy.layers.inet import TCP
@@ -15,8 +17,19 @@ from scapy.layers.inet6 import Raw
 
 from framework.logger import get_logger
 
-T = TypeVar("T")
+if TYPE_CHECKING:
+    from framework.stateful import RegularKernelSocketNetworkStateful
+
 logger = get_logger("utils")
+
+
+class ClonerCallable(Protocol):
+    def __call__(
+        self,
+        cloner: RegularKernelSocketNetworkStateful,
+        amount: int,
+        fabric: Optional[Type[RegularKernelSocketNetworkStateful]] = None,
+    ) -> list[RegularKernelSocketNetworkStateful]: ...
 
 
 class RetryException(Exception):
@@ -80,71 +93,6 @@ async def run_cmd(
         return await _log_when_done(process)
 
     return process, None, None
-
-
-def client_cloner(client: T, amount: int, fabric=None) -> list[T]:
-    ports = client.generate_new_ports(amount)
-    addresses = client.generate_new_addresses(amount)
-    class_to_create = client.__class__
-
-    if fabric:
-        class_to_create = fabric
-
-    clients = []
-
-    for port, address in zip(ports, addresses):
-        clients.append(
-            class_to_create(
-                network_interface=client.network_interface,
-                ipv4=address if client.ipv4 else None,
-                ipv4_mask=client.ipv4_mask if client.ipv4 else None,
-                ipv6=address if client.ipv6 else None,
-                ipv6_mask=client.ipv6_mask if client.ipv6 else None,
-                port=port,
-                remote_ip=client.remote_ip,
-                remote_port=client.remote_port,
-                logger=client.logger,
-                namespace=client.namespace,
-                testing_model=client.testing_model,
-                timeout=client.timeout,
-            )
-        )
-
-    return clients
-
-
-def server_cloner(
-    server: T,
-    amount: int,
-    fabric=None,
-) -> list[T]:
-    ports = server.generate_new_ports(amount)
-    addresses = server.generate_new_addresses(amount)
-    class_to_create = server.__class__
-
-    if fabric:
-        class_to_create = fabric
-
-    servers = []
-
-    for port, address in zip(ports, addresses):
-        servers.append(
-            class_to_create(
-                network_interface=server.network_interface,
-                ipv4=address if server.ipv4 else None,
-                ipv4_mask=server.ipv4_mask if server.ipv4 else None,
-                ipv6=address if server.ipv6 else None,
-                ipv6_mask=server.ipv6_mask if server.ipv6 else None,
-                port=port,
-                logger=server.logger,
-                testing_model=server.testing_model,
-                rpc_connection=server.rpc_connection,
-                timeout=server.timeout,
-                namespace=server.namespace,
-            )
-        )
-
-    return servers
 
 
 @asynccontextmanager

--- a/t/func/tests/conftest.py
+++ b/t/func/tests/conftest.py
@@ -27,6 +27,7 @@ from framework.networks import (
 )
 from framework.rpc.client import RpcClient
 from framework.stateful import RegularKernelSocketNetworkStateful
+from framework.utils import ClonerCallable
 from framework.xfw import XFW, XFWRemote
 
 
@@ -547,6 +548,102 @@ def protocol(request) -> Literal["udp", "tcp"]:
 @pytest.fixture(params=["ip4", "ip6"])
 def ip_version(request) -> Literal["ip4", "ip6"]:
     return request.param
+
+
+@pytest.fixture(scope="function")
+async def client_cloner(server_cloner) -> ClonerCallable:
+    """
+    server_cloner: The server cloner fixture. Required to enforce the correct teardown sequence in pytest.
+
+    Note on Lifecycle & Teardown Order:
+        Pytest executes fixture teardown blocks (the code after `yield`) in
+        reverse order of their initialization (LIFO - Last In, First Out).
+
+        By making `client_cloner` explicitly depend on `server_cloner`, we
+        guarantee the following graceful shutdown sequence after each test:
+
+        1. Client Cleanup First: The teardown block in this fixture runs first,
+           stopping and cleaning up all active client clones.
+        2. Server Cleanup Second: Pytest then proceeds to `server_cloner`'s
+           teardown block, shutting down the servers.
+
+        This specific order prevents active clients from attempting to send
+        traffic to already closed server sockets, avoiding intermittent
+        'ConnectionResetError' exceptions or hung test processes.
+    """
+    _clones: list[RegularKernelSocketNetworkStateful] = []
+
+    def wrapper(
+        cloner: RegularKernelSocketNetworkStateful, amount: int, fabric: Optional[typing.Any] = None
+    ) -> list[RegularKernelSocketNetworkStateful]:
+        nonlocal _clones
+
+        ports = cloner.generate_new_ports(amount)
+        addresses = cloner.generate_new_addresses(amount)
+
+        class_to_create = fabric if fabric else cloner.__class__
+
+        for port, address in zip(ports, addresses):
+            _clones.append(
+                class_to_create(
+                    network_interface=cloner.network_interface,
+                    ipv4=address if cloner.ipv4 else None,
+                    ipv4_mask=cloner.ipv4_mask if cloner.ipv4 else None,
+                    ipv6=address if cloner.ipv6 else None,
+                    ipv6_mask=cloner.ipv6_mask if cloner.ipv6 else None,
+                    port=port,
+                    remote_ip=cloner.remote_ip,
+                    remote_port=cloner.remote_port,
+                    logger=cloner.logger,
+                    namespace=cloner.namespace,
+                    testing_model=cloner.testing_model,
+                    timeout=cloner.timeout,
+                )
+            )
+        return _clones
+
+    yield wrapper
+
+    await asyncio.gather(*[clone.stop() for clone in _clones], return_exceptions=True)
+    _clones.clear()
+
+
+@pytest.fixture(scope="function")
+async def server_cloner() -> ClonerCallable:
+    _clones: list[RegularKernelSocketNetworkStateful] = []
+
+    def wrapper(
+        cloner: RegularKernelSocketNetworkStateful, amount: int, fabric: Optional[typing.Any] = None
+    ) -> list[RegularKernelSocketNetworkStateful]:
+        nonlocal _clones
+
+        ports = cloner.generate_new_ports(amount)
+        addresses = cloner.generate_new_addresses(amount)
+
+        class_to_create = fabric if fabric else cloner.__class__
+
+        for port, address in zip(ports, addresses):
+            _clones.append(
+                class_to_create(
+                    network_interface=cloner.network_interface,
+                    ipv4=address if cloner.ipv4 else None,
+                    ipv4_mask=cloner.ipv4_mask if cloner.ipv4 else None,
+                    ipv6=address if cloner.ipv6 else None,
+                    ipv6_mask=cloner.ipv6_mask if cloner.ipv6 else None,
+                    port=port,
+                    logger=cloner.logger,
+                    testing_model=cloner.testing_model,
+                    rpc_connection=cloner.rpc_connection,
+                    timeout=cloner.timeout,
+                    namespace=cloner.namespace,
+                )
+            )
+        return _clones
+
+    yield wrapper
+
+    await asyncio.gather(*[clone.stop() for clone in _clones], return_exceptions=True)
+    _clones.clear()
 
 
 @pytest.fixture

--- a/t/func/tests/test_always_first_self.py
+++ b/t/func/tests/test_always_first_self.py
@@ -19,7 +19,6 @@ from framework.asyn import (
 )
 from framework.cmp import check_connection
 from framework.stateful import RegularKernelSocketNetworkStateful
-from framework.utils import client_cloner
 
 
 @pytest.mark.nic_e1000_warmup
@@ -107,8 +106,7 @@ async def test_dns_udp_client_server(
 
 
 async def test_raw_socket_tcp_traffic_collisions(
-    tcp_raw_client: TcpRawClient,
-    tcp_server: TcpServer,
+    tcp_raw_client: TcpRawClient, tcp_server: TcpServer, client_cloner
 ):
     tcp_raw_client_2 = client_cloner(tcp_raw_client, 1)[0]
 

--- a/t/func/tests/test_dst_stats.py
+++ b/t/func/tests/test_dst_stats.py
@@ -7,7 +7,7 @@ import pytest
 from scapy.layers.inet import TCP
 
 from framework.asyn import TcpRawClient, TcpServer, UdpClient, UdpServer
-from framework.utils import client_cloner, compare_metrics_diff
+from framework.utils import compare_metrics_diff
 from framework.xfw import XFW
 
 
@@ -72,10 +72,11 @@ async def test_dst_udp_stats(
     udp_ip6_server: UdpServer,
     udp_ip4_client: UdpClient,
     udp_ip6_client: UdpClient,
+    client_cloner,
 ):
     server = locals().get(f"udp_{ip}_server")
     client = locals().get(f"udp_{ip}_client")
-    client_2 = client_cloner(client=client, amount=1)[0]
+    client_2 = client_cloner(cloner=client, amount=1)[0]
 
     await server.start()
     await client.start()
@@ -151,6 +152,7 @@ async def test_dst_tcp_stats(
     tcp_ip6_server: TcpServer,
     tcp_ip4_raw_client: TcpRawClient,
     tcp_ip6_raw_client: TcpRawClient,
+    client_cloner,
 ):
     """
     We have to use in this test TcpRawSocket because
@@ -161,7 +163,7 @@ async def test_dst_tcp_stats(
     """
     server: TcpServer = locals().get(f"tcp_{ip}_server")
     client: TcpRawClient = locals().get(f"tcp_{ip}_raw_client")
-    client_2: TcpRawClient = client_cloner(client=client, amount=1)[0]
+    client_2: TcpRawClient = client_cloner(cloner=client, amount=1)[0]
 
     await server.start()
     await client.start()

--- a/t/func/tests/test_evaluating_mode.py
+++ b/t/func/tests/test_evaluating_mode.py
@@ -19,7 +19,7 @@ from framework.asyn import (
 from framework.clickhouse import ClickhouseClient
 from framework.cmp import check_connection
 from framework.stateful import RegularKernelSocketNetworkStateful
-from framework.utils import client_cloner, metrics_increased
+from framework.utils import metrics_increased
 from framework.xfw import XFW
 
 
@@ -348,11 +348,12 @@ async def test_multiple_requests_logs_without_blocking(
     clickhouse_client: ClickhouseClient,
     udp_ip4_client: UdpClient,
     udp_ip4_server: UdpServer,
+    client_cloner,
 ):
     await clickhouse_client.connect()
     await udp_ip4_server.start()
 
-    clients = client_cloner(client=udp_ip4_client, amount=10)
+    clients = client_cloner(cloner=udp_ip4_client, amount=10)
     for client in clients:
         await client.start()
 

--- a/t/func/tests/test_icmp_stats.py
+++ b/t/func/tests/test_icmp_stats.py
@@ -6,7 +6,7 @@ import asyncio
 import pytest
 
 from framework.asyn import IcmpRawClient, UdpServer
-from framework.utils import client_cloner, compare_metrics_diff
+from framework.utils import compare_metrics_diff
 from framework.xfw import XFW
 
 
@@ -108,6 +108,7 @@ async def test_icmp_stats(
     udp_ip6_server: UdpServer,
     icmp_ip4_raw_client: IcmpRawClient,
     icmp_ip6_raw_client: IcmpRawClient,
+    client_cloner,
 ):
     """
     TODO: The IP6 tests have a diapason of values. The minimal
@@ -118,7 +119,7 @@ async def test_icmp_stats(
     """
     await locals().get(f"udp_{protocol}_server").start()
     client = locals().get(f"icmp_{protocol}_raw_client")
-    client_2 = client_cloner(client=client, amount=1)[0]
+    client_2 = client_cloner(cloner=client, amount=1)[0]
 
     await client.start()
     await client_2.start()

--- a/t/func/tests/test_net.py
+++ b/t/func/tests/test_net.py
@@ -6,7 +6,6 @@ import pytest
 from config import ConfigSettings
 from framework.cmp import check_connection
 from framework.stateful import RegularKernelSocketNetworkStateful
-from framework.utils import client_cloner, server_cloner
 from framework.xfw import XFW
 
 
@@ -19,10 +18,9 @@ async def backend_protected(
 
 @pytest.fixture
 async def backend_not_protected(
-    backend_protected: RegularKernelSocketNetworkStateful,
-    config: ConfigSettings,
+    backend_protected: RegularKernelSocketNetworkStateful, config: ConfigSettings, server_cloner
 ) -> RegularKernelSocketNetworkStateful:
-    new_server = server_cloner(server=backend_protected, amount=1)[0]
+    new_server = server_cloner(cloner=backend_protected, amount=1)[0]
     yield new_server
     await new_server.stop()
 
@@ -42,8 +40,9 @@ async def client_protected(
 async def client_not_protected(
     client: RegularKernelSocketNetworkStateful,
     backend_not_protected: RegularKernelSocketNetworkStateful,
+    client_cloner,
 ):
-    new_client = client_cloner(client=client, amount=1)[0]
+    new_client = client_cloner(cloner=client, amount=1)[0]
     new_client.remote_ip = backend_not_protected.ip
     new_client.remote_port = backend_not_protected.port
 

--- a/t/func/tests/test_src_stats.py
+++ b/t/func/tests/test_src_stats.py
@@ -6,8 +6,8 @@ import asyncio
 import pytest
 from scapy.layers.inet import TCP
 
-from framework.asyn import TcpClient, TcpRawClient, TcpServer, UdpClient, UdpServer
-from framework.utils import client_cloner, compare_metrics_diff
+from framework.asyn import TcpRawClient, TcpServer, UdpClient, UdpServer
+from framework.utils import compare_metrics_diff
 from framework.xfw import XFW
 
 
@@ -197,10 +197,11 @@ async def test_src_udp_stats(
     udp_ip6_server: UdpServer,
     udp_ip4_client: UdpClient,
     udp_ip6_client: UdpClient,
+    client_cloner,
 ):
     server = locals().get(f"udp_{ip}_server")
     client = locals().get(f"udp_{ip}_client")
-    client_2 = client_cloner(client=client, amount=1)[0]
+    client_2 = client_cloner(cloner=client, amount=1)[0]
 
     await server.start()
     await client.start()
@@ -433,6 +434,7 @@ async def test_src_tcp_stats(
     tcp_ip6_server: TcpServer,
     tcp_ip4_raw_client: TcpRawClient,
     tcp_ip6_raw_client: TcpRawClient,
+    client_cloner,
 ):
     """
     We have to use in this test TcpRawSocket because
@@ -443,7 +445,7 @@ async def test_src_tcp_stats(
     """
     server: TcpServer = locals().get(f"tcp_{ip}_server")
     client: TcpRawClient = locals().get(f"tcp_{ip}_raw_client")
-    client_2: TcpRawClient = client_cloner(client=client, amount=1)[0]
+    client_2: TcpRawClient = client_cloner(cloner=client, amount=1)[0]
 
     await server.start()
     await client.start()

--- a/t/func/tests/test_tcp_anomaly_filter_stats.py
+++ b/t/func/tests/test_tcp_anomaly_filter_stats.py
@@ -13,7 +13,7 @@ from framework.asyn import (
     TcpV4Server,
     TcpV6Server,
 )
-from framework.utils import client_cloner, compare_metrics_diff, get_tcp_packet
+from framework.utils import compare_metrics_diff, get_tcp_packet
 from framework.xfw import XFW
 
 
@@ -96,11 +96,12 @@ async def test_common(
     tcp_ip6_server: TcpV6Server,
     tcp_ip4_raw_client: TcpIpV4RawClient,
     tcp_ip6_raw_client: TcpIpV6RawClient,
+    client_cloner,
 ):
     server = locals().get(f"tcp_{protocol}_server")
     client = locals().get(f"tcp_{protocol}_raw_client")
     client.auto_ack_seq = False
-    client_2 = client_cloner(client=client, amount=1)[0]
+    client_2 = client_cloner(cloner=client, amount=1)[0]
     client_2.auto_ack_seq = False
 
     await server.start()
@@ -151,11 +152,12 @@ async def test_zero_port(
     tcp_ip6_server: TcpV6Server,
     tcp_ip4_raw_client: TcpIpV4RawClient,
     tcp_ip6_raw_client: TcpIpV6RawClient,
+    client_cloner,
 ):
     server = locals().get(f"tcp_{protocol}_server")
     client: TcpRawClient = locals().get(f"tcp_{protocol}_raw_client")
     client.auto_ack_seq = False
-    client_2: TcpRawClient = client_cloner(client=client, amount=1)[0]
+    client_2: TcpRawClient = client_cloner(cloner=client, amount=1)[0]
     client_2.auto_ack_seq = False
 
     await server.start()

--- a/t/func/tests/test_tcp_auth_filter_stats.py
+++ b/t/func/tests/test_tcp_auth_filter_stats.py
@@ -7,7 +7,7 @@ import pytest
 from scapy.layers.inet import TCP
 
 from framework.asyn import TcpRawClient, TcpRawServer
-from framework.utils import client_cloner, compare_metrics_diff
+from framework.utils import compare_metrics_diff
 from framework.xfw import XFW
 
 
@@ -44,10 +44,11 @@ async def test_block_non_existing_session(
     tcp_ip4_raw_client: TcpRawClient,
     tcp_ip6_raw_server: TcpRawServer,
     tcp_ip6_raw_client: TcpRawClient,
+    client_cloner,
 ):
     client = locals().get(f"tcp_{protocol}_raw_client")
     client.auto_ack_seq = False
-    client_2 = client_cloner(client=client, amount=1)[0]
+    client_2 = client_cloner(cloner=client, amount=1)[0]
     client_2.auto_ack_seq = False
 
     await client.start()

--- a/t/func/tests/test_tcp_flags_filter_stats.py
+++ b/t/func/tests/test_tcp_flags_filter_stats.py
@@ -11,7 +11,7 @@ from framework.asyn import (
     TcpIpV6RawClient,
     TcpIpV6RawServer,
 )
-from framework.utils import client_cloner, compare_metrics_diff
+from framework.utils import compare_metrics_diff
 from framework.xfw import XFW
 
 
@@ -85,11 +85,12 @@ async def test_tcp_flags_filter_stats(
     tcp_ip6_raw_server: TcpIpV6RawServer,
     tcp_ip4_raw_client: TcpIpV4RawClient,
     tcp_ip6_raw_client: TcpIpV6RawClient,
+    client_cloner,
 ):
     server = locals().get(f"tcp_{protocol}_raw_server")
     client = locals().get(f"tcp_{protocol}_raw_client")
     client.auto_ack_seq = False
-    client_2 = client_cloner(client=client, amount=1)[0]
+    client_2 = client_cloner(cloner=client, amount=1)[0]
     client_2.auto_ack_seq = False
 
     await server.start()

--- a/t/func/tests/test_tcp_syncookies.py
+++ b/t/func/tests/test_tcp_syncookies.py
@@ -12,14 +12,13 @@ from scapy.layers.inet import TCP
 
 from config import ConfigSettings
 from framework.asyn import (
-    TcpClient,
     TcpIpV4RawClient,
     TcpIpV6RawClient,
     TcpRawClient,
     TcpServer,
 )
 from framework.fabrics import client_fabric
-from framework.utils import client_cloner, get_tcp_packet, run_in_background
+from framework.utils import get_tcp_packet, run_in_background
 from framework.xfw import XFW
 
 SynStats = tuple[int, int, int]
@@ -208,10 +207,10 @@ async def xfw_with_forced_syncookie(xfw: XFW) -> XFW:
 
 @pytest.fixture
 async def group_of_clients(
-    tcp_syncookie_client: TcpRawSynCookieClient,
+    tcp_syncookie_client: TcpRawSynCookieClient, client_cloner
 ) -> list[TcpRawSynCookieClient]:
     clients: list[TcpRawClient] = client_cloner(
-        client=tcp_syncookie_client,
+        cloner=tcp_syncookie_client,
         amount=2,
     )
 

--- a/t/func/tests/test_tfw_logger.py
+++ b/t/func/tests/test_tfw_logger.py
@@ -10,7 +10,6 @@ import pytest
 from framework.asyn import UdpClient, UdpServer
 from framework.clickhouse import ClickhouseClient
 from framework.cmp import check_connection
-from framework.utils import client_cloner
 from framework.xfw import XFW
 
 
@@ -131,11 +130,12 @@ async def test_multiple_requests_logs(
     clickhouse_client: ClickhouseClient,
     udp_ip4_client: UdpClient,
     udp_ip4_server: UdpServer,
+    client_cloner,
 ):
     await clickhouse_client.connect()
     await udp_ip4_server.start()
 
-    clients = client_cloner(client=udp_ip4_client, amount=10)
+    clients = client_cloner(cloner=udp_ip4_client, amount=10)
     for client in clients:
         await client.start()
 
@@ -149,7 +149,7 @@ async def test_multiple_requests_logs(
         """)
 
     results = await asyncio.gather(
-        *[check_connection(client, udp_ip4_client) for client in clients]
+        *[check_connection(client, udp_ip4_server) for client in clients]
     )
 
     assert not any(results)

--- a/t/func/tests/test_udp_anomaly_stats.py
+++ b/t/func/tests/test_udp_anomaly_stats.py
@@ -12,7 +12,7 @@ from framework.asyn import (
     UdpV4Server,
     UdpV6Server,
 )
-from framework.utils import client_cloner, compare_metrics_diff
+from framework.utils import compare_metrics_diff
 from framework.xfw import XFW
 
 
@@ -48,10 +48,11 @@ async def test_zero_port(
     udp_ip6_server: UdpV6Server,
     udp_ip4_raw_client: UdpIpV4RawClient,
     udp_ip6_raw_client: UdpIpV6RawClient,
+    client_cloner,
 ):
     server = locals().get(f"udp_{protocol}_server")
     client: UdpRawClient = locals().get(f"udp_{protocol}_raw_client")
-    client_2: UdpRawClient = client_cloner(client=client, amount=1)[0]
+    client_2: UdpRawClient = client_cloner(cloner=client, amount=1)[0]
 
     await server.start()
     await client.start()

--- a/t/func/tests/test_vlan.py
+++ b/t/func/tests/test_vlan.py
@@ -15,7 +15,6 @@ from scapy.layers.l2 import Dot1Q
 
 from framework.asyn.ether_raw_client import EtherRawClient
 from framework.asyn.ether_raw_server import EtherRawServer
-from framework.utils import server_cloner
 from framework.xfw import XFW
 
 SOL_PACKET = 263
@@ -105,7 +104,7 @@ class Ether802Dot1QServer(EtherRawServer):
 
 
 @pytest.fixture
-async def ether_802_dot_1q_server(ether_raw_server: EtherRawServer):
+async def ether_802_dot_1q_server(ether_raw_server: EtherRawServer, server_cloner):
     server = server_cloner(ether_raw_server, fabric=Ether802Dot1QServer, amount=1)[0]
     yield server
     await server.stop()

--- a/t/func/tests/test_xfw.py
+++ b/t/func/tests/test_xfw.py
@@ -14,7 +14,6 @@ from framework.stateful import RegularKernelSocketNetworkStateful
 from framework.utils import (
     RetryException,
     RetryNotHelpedException,
-    client_cloner,
 )
 from framework.xfw import XFW, State
 
@@ -411,13 +410,14 @@ async def test_restart_under_traffic(
     xfw: XFW,
     tcp_server: TcpServer,
     tcp_client: TcpClient,
+    client_cloner,
 ):
     messages_pps = 0
     load_duration = 10
     load_duration_middle = load_duration / 2
     tasks = []
     clients = client_cloner(
-        client=tcp_client,
+        cloner=tcp_client,
         amount=10,
     )
 
@@ -425,18 +425,18 @@ async def test_restart_under_traffic(
     tcp_server.log_request = False
     await tcp_server.start()
 
-    for client in clients:
-        client.timeout = 5
-        client.log_request = False
-        await client.start()
+    for cl in clients:
+        cl.timeout = 5
+        cl.log_request = False
+        await cl.start()
 
-    for client in clients:
+    for cl in clients:
         tasks.append(
             asyncio.create_task(
-                client.generate_traffic(
+                cl.generate_traffic(
                     messages_pps=messages_pps,
                     duration=load_duration,
-                    function=getattr(client, function),
+                    function=getattr(cl, function),
                 )
             )
         )
@@ -451,7 +451,7 @@ async def test_restart_under_traffic(
         await xfw.restart_daemon()
 
     await asyncio.gather(*tasks)
-    client_responses = sum(client.resp_n for client in clients)
+    client_responses = sum(cl.resp_n for cl in clients)
     server_requests = tcp_server.req_n
     assert (
         client_responses == server_requests


### PR DESCRIPTION
onvert `client_cloner` and `server_cloner` to context managers

This ensures that all spawned services are automatically stopped in the
`finally` block, even if a test fails or encounters an error. Removes the
need for manual cleanup loops inside tests or fixtures.