### PR TITLE
tests: refactor XFW fixture to use try...finally for reliable cleanup

### DIFF
--- a/t/func/tests/conftest.py
+++ b/t/func/tests/conftest.py
@@ -247,12 +247,9 @@ async def xfw(
     )
     try:
         await xfw.start()
-    except AssertionError as e:
+        yield xfw
+    finally:
         await xfw.stop()
-        pytest.fail(f"The XFW service have not started in time. Error: {e}")
-
-    yield xfw
-    await xfw.stop()
 
 
 @pytest.fixture


### PR DESCRIPTION
- ensures xfw.stop() is always called after start or test execution.