### PR TITLE
bpf: fix memcmp builtin mapping

### DIFF
--- a/bpf/compiler.h
+++ b/bpf/compiler.h
@@ -51,7 +51,7 @@ extern unsigned long CONFIG_HZ __kconfig;
 #endif
 
 #ifndef memcmp
-#define memcmp(s1, s2, n)	__builtin_memcpy((s1), (s2), (n))
+#define memcmp(s1, s2, n)	__builtin_memcmp((s1), (s2), (n))
 #endif
 
 #ifndef memmove


### PR DESCRIPTION
The BPF compiler shim mapped memcmp() to __builtin_memcpy(), so a future caller would overwrite the first argument and receive a pointer value instead of comparison results.

Map memcmp() to __builtin_memcmp() to preserve the expected comparison semantics.