### PR TITLE
bpf: fix TCP option parser offset handling

### DIFF
--- a/bpf/tcp_syncookies.h
+++ b/bpf/tcp_syncookies.h
@@ -210,13 +210,18 @@ tcp_parse_opts(XfwGlobalCtx *ctx, XfwTCPOpts *opts)
 	/* The maximum lenght of options is 40 bytes (RFC 9293 3.1). */
 	VERIFY_TRUE_OR_RETURN(o + 40 >= o_end, -E2BIG);
 
+	/*
+	 * bpf_for() rewrites i on each iteration. Keep the TCP option offset
+	 * separate so option lengths can skip over value bytes.
+	 */
+	uint8_t off = 0;
 	uint8_t i;
 	bpf_for (i, 0, 40) {
-		if (o + i >= o_end || unlikely(o + i >= d_end))
+		if (o + off >= o_end || unlikely(o + off >= d_end))
 			return 0;
 
 		/* First byte is kind of the option. */
-		switch (o[i]) {
+		switch (o[off]) {
 		case TCPOPT_EOL:
 			/*
 			 * If non zero values are present after EOL, then the
@@ -228,27 +233,27 @@ tcp_parse_opts(XfwGlobalCtx *ctx, XfwTCPOpts *opts)
 			return 0;
 
 		case TCPOPT_NOP:
-			++i;
+			++off;
 			continue;
 
 		case TCPOPT_WSCALE:
 			/* RFC 7323 2.2: kind, len=3, 1 byte val */
-			e = o + i + TCPOPT_WSCALE_SZ;
+			e = o + off + TCPOPT_WSCALE_SZ;
 			VERIFY_TRUE_OR_RETURN(e <= o_end && e <= d_end, -EINVAL);
-			VERIFY_TRUE_OR_RETURN(o[i + 1] == TCPOPT_WSCALE_SZ, -EINVAL);
-			opts->wscale = o[i + 2];
-			VERIFY_TRUE_OR_RETURN(o[i] <= TCPOPT_WSCALE_MAX, -EINVAL);
-			i += TCPOPT_WSCALE_SZ;
+			VERIFY_TRUE_OR_RETURN(o[off + 1] == TCPOPT_WSCALE_SZ, -EINVAL);
+			opts->wscale = o[off + 2];
+			VERIFY_TRUE_OR_RETURN(o[off] <= TCPOPT_WSCALE_MAX, -EINVAL);
+			off += TCPOPT_WSCALE_SZ;
 			continue;
 
 		case TCPOPT_SACK_PERM:
 			/* RFC 2018 2: kind, len=2 */
-			e = o + i + TCPOPT_SACK_PERM_SZ;
+			e = o + off + TCPOPT_SACK_PERM_SZ;
 			VERIFY_TRUE_OR_RETURN(e <= o_end && e <= d_end, -EINVAL);
-			VERIFY_TRUE_OR_RETURN(o[i + 1] == TCPOPT_SACK_PERM_SZ,
+			VERIFY_TRUE_OR_RETURN(o[off + 1] == TCPOPT_SACK_PERM_SZ,
 					      -EINVAL);
 			opts->sack_perm = 1;
-			i += TCPOPT_SACK_PERM_SZ;
+			off += TCPOPT_SACK_PERM_SZ;
 			continue;
 
 		case TCPOPT_TIMESTAMP:
@@ -256,13 +261,13 @@ tcp_parse_opts(XfwGlobalCtx *ctx, XfwTCPOpts *opts)
 			 * RFC 7323 3.2:
 			 * kind, len=10, TS val 4 bytes, TS echo (tsecr) 4 bytes
 			 */
-			e = o + i + TCPOPT_TIMESTAMP_SZ;
+			e = o + off + TCPOPT_TIMESTAMP_SZ;
 			VERIFY_TRUE_OR_RETURN(e <= o_end && e <= d_end, -EINVAL);
-			VERIFY_TRUE_OR_RETURN(o[i + 1] == TCPOPT_TIMESTAMP_SZ, -EINVAL);
+			VERIFY_TRUE_OR_RETURN(o[off + 1] == TCPOPT_TIMESTAMP_SZ, -EINVAL);
 			/* RFC 7323 4.3: ignore duplicate timestamp options. */
 			if (likely(!opts->ts))
-				opts->ts = get_unaligned((__be32 *)(o + i + 2));
-			i += TCPOPT_TIMESTAMP_SZ;
+				opts->ts = get_unaligned((__be32 *)(o + off + 2));
+			off += TCPOPT_TIMESTAMP_SZ;
 			continue;
 
 		default:
@@ -271,13 +276,13 @@ tcp_parse_opts(XfwGlobalCtx *ctx, XfwTCPOpts *opts)
 			 * Only NOP and EOL have 1 byte lengh, all others must
 			 * have length field (RFC 9293 3.1).
 			 */
-			e = o + i + 2;
+			e = o + off + 2;
 			VERIFY_TRUE_OR_RETURN(e <= o_end && e <= d_end, -EINVAL);
-			uint8_t olen = o[i + 1];
+			uint8_t olen = o[off + 1];
 			VERIFY_TRUE_OR_RETURN(olen >= 2, -EINVAL);
-			e = o + i + olen;
+			e = o + off + olen;
 			VERIFY_TRUE_OR_RETURN(e <= o_end && e <= d_end, -EINVAL);
-			i += olen;
+			off += olen;
 			continue;
 		}
 	}


### PR DESCRIPTION
tcp_parse_opts() expected to jump over option bytes by changing the loop variable, like a normal "for" loop.

But bpf_for() is different: libbpf assigns the variable from its numbers iterator on every iteration, even you offset variable, it will return back. That means changes made inside the loop are lost before the next pass.

Use a separate option offset for parsing and keep bpf_for() only as the bounded iteration guard.