### PR TITLE
Fix IPv4 destination default selection

### DIFF
--- a/bpf/dst.h
+++ b/bpf/dst.h
@@ -24,7 +24,11 @@ xfw_dst_default_by_key(const XfwDstKey *dst_key)
 {
 	uint8_t dst_default;
 
-	if (dst_key->ipver == bpf_ntohs(ETH_P_IP)) {
+	/*
+	 * XfwDstKey::ipver uses XFW_IP_VER_4/6. This differs from
+	 * XfwGlobalCtx::ipver, which stores ETH_P_IP/ETH_P_IPV6.
+	 */
+	if (dst_key->ipver == XFW_IP_VER_4) {
 		if (dst_key->proto == XFW_L4_PROTO_TCP) {
 			dst_default = XFW_DEFAULT_DST_TCP_IP4;
 		} else {


### PR DESCRIPTION
XfwDstKey.ipver stores XFW_IP_VER_4/6, not the ETH_P_* EtherType values used by XfwGlobalCtx.ipver. Compare destination keys against XFW_IP_VER_4 so IPv4 traffic without an explicit destination rule uses IPv4 defaults.