### PR TITLE
Fix TCP window scale option validation

### DIFF
--- a/bpf/tcp_syncookies.h
+++ b/bpf/tcp_syncookies.h
@@ -237,7 +237,7 @@ tcp_parse_opts(XfwGlobalCtx *ctx, XfwTCPOpts *opts)
 			VERIFY_TRUE_OR_RETURN(e <= o_end && e <= d_end, -EINVAL);
 			VERIFY_TRUE_OR_RETURN(o[i + 1] == TCPOPT_WSCALE_SZ, -EINVAL);
 			opts->wscale = o[i + 2];
-			VERIFY_TRUE_OR_RETURN(o[i] <= TCPOPT_WSCALE_MAX, -EINVAL);
+			VERIFY_TRUE_OR_RETURN(o[i + 2] <= TCPOPT_WSCALE_MAX, -EINVAL);
 			i += TCPOPT_WSCALE_SZ;
 			continue;
 


### PR DESCRIPTION
The parser compares the window scale field with TCPOPT_WSCALE_MAX, so checking o[i] looks like a typo: o[i] is the option kind byte, while o[i + 2] is the one-byte window scale value. Validate o[i + 2] so values above 14 are rejected instead of encoded into the syncookie.
i - kind (TCPOPT_WSCALE == 3)
o[i + 1] - length (3)
o[i + 2] - actual scale value