### PR TITLE
Fix TCP options parsing

### DIFF
--- a/bpf/ctx.h
+++ b/bpf/ctx.h
@@ -66,6 +66,7 @@ typedef struct XfwGlobalCtx {
 	XfwMd		*ctx;
 	struct ethhdr	*eth;
 	union {
+		void		*iph;
 		struct iphdr	*iph4;
 		struct ipv6hdr	*iph6;
 	};

--- a/bpf/ctx.h
+++ b/bpf/ctx.h
@@ -65,10 +65,14 @@ typedef struct XfwGlobalCtx {
 	uint8_t		l4_proto;
 	XfwMd		*ctx;
 	struct ethhdr	*eth;
-	struct iphdr	*iph4;
-	struct ipv6hdr	*iph6;
-	struct tcphdr	*th;
-	struct udphdr	*uh;
+	union {
+		struct iphdr	*iph4;
+		struct ipv6hdr	*iph6;
+	};
+	union {
+		struct tcphdr	*th;
+		struct udphdr	*uh;
+	};
 	uint64_t	ts_jiff;
 	XfwIp		ilog_addr;
 } XfwGlobalCtx;

--- a/bpf/dns.h
+++ b/bpf/dns.h
@@ -94,10 +94,10 @@ STATIC_ASSERT(sizeof(XfwPacketMetadata) <= 32,
 
 typedef struct XfwDnsCtx {
 	XfwMd		*ctx;
+	XfwPerCpuStats	*g_stats;
 	XfwHdrCursor	hdr_cur;
 	XfwIp		ilog_addr;
 	uint32_t	pkt_sz;
-	XfwPerCpuStats	*g_stats;
 } XfwDnsCtx;
 
 SIMPLE_PARSE_FUNC_DECL(parse_dnshdr, XfwDnsHdr);
@@ -423,11 +423,11 @@ ingress_dns_filter(XfwGlobalCtx *ctx)
 
 	uint16_t cur_pos = ctx->hdr_cur.pos - XFW_CTX_DATA_BGN(ctx->ctx);
 	uint16_t is_ipv4, ip_pos;
-	if (ctx->iph4) {
+	if (ctx->ipver == bpf_ntohs(ETH_P_IP)) {
 		is_ipv4 = 1;
 		ip_pos = (void*)ctx->iph4 - XFW_CTX_DATA_BGN(ctx->ctx);
 	}
-	else if (likely(ctx->iph6)) {
+	else if (ctx->ipver == bpf_ntohs(ETH_P_IPV6)) {
 		is_ipv4 = 0;
 		ip_pos = (void*)ctx->iph6 - XFW_CTX_DATA_BGN(ctx->ctx);
 	}

--- a/bpf/dst.h
+++ b/bpf/dst.h
@@ -35,30 +35,32 @@ static __always_inline bool
 populate_dst_info(const XfwGlobalCtx *ctx, XfwDstKey *key, __u8 *default_idx)
 {
 	key->proto = (uint8_t)ctx->l4_proto;
-	if (ctx->iph4) {
+	if (ctx->ipver == bpf_ntohs(ETH_P_IP)) {
 		key->ipver = XFW_IP_VER_4;
 		xfw_ipv4_to_ipv6_mapped(ctx->iph4->daddr, key->addr.addr32);
-		if (ctx->th) {
+		if (ctx->l4_proto == XFW_L4_PROTO_TCP) {
 			key->port = ctx->th->dest;
 			*default_idx = XFW_DEFAULT_DST_TCP_IP4;
 			return true;
 		}
-		if (ctx->uh) {
+		if (ctx->l4_proto == XFW_L4_PROTO_UDP) {
 			key->port = ctx->uh->dest;
 			*default_idx = XFW_DEFAULT_DST_UDP_IP4;
 			return true;
 		}
 		return false;
 	}
-	if (ctx->iph6) {
+	if (ctx->ipver == bpf_ntohs(ETH_P_IPV6)) {
+		VERIFY_TRUE_OR_RETURN((void *)(ctx->iph6 + 1) <= ctx->hdr_cur.end,
+				      false);
 		key->ipver = XFW_IP_VER_6;
 		key->addr.in6 = ctx->iph6->daddr;
-		if (ctx->th) {
+		if (ctx->l4_proto == XFW_L4_PROTO_TCP) {
 			key->port = ctx->th->dest;
 			*default_idx = XFW_DEFAULT_DST_TCP_IP6;
 			return true;
 		}
-		if (ctx->uh) {
+		if (ctx->l4_proto == XFW_L4_PROTO_UDP) {
 			key->port = ctx->uh->dest;
 			*default_idx = XFW_DEFAULT_DST_UDP_IP6;
 			return true;
@@ -73,6 +75,7 @@ xfw_dst_filter(const XfwGlobalCtx *ctx)
 {
 	XfwDstKey dst_key;
 	uint8_t dst_default;
+
 	XFW_ASSERT(populate_dst_info(ctx, &dst_key, &dst_default));
 
 	XfwActionRule *rule = bpf_map_lookup_elem(

--- a/bpf/log.h
+++ b/bpf/log.h
@@ -45,7 +45,7 @@ uint32_t pkt_id = 0;
  *   VERIFY_TRUE_OR_RETURN(foo, -EINVAL); // just to satisfy the verifier
  *
  *   if (unlikely(bar))			  // normal program logic
- *   	return XFW_CTX_DROP;
+ *   	return XFW_MAKE_CTX_DROP(...);
  */
 #define VERIFY_TRUE_OR_RETURN(v, r)					\
 do {									\

--- a/bpf/log.h
+++ b/bpf/log.h
@@ -38,6 +38,15 @@ uint32_t pkt_id = 0;
 #define XFW_CTX_DBG(fmt, args...)	XFW_DBG("[in] " fmt, ##args)
 #endif
 
+/*
+ * Prefer to use the macro for the verifier specific checks, not the logic
+ * necessary checks, e.g.
+ *
+ *   VERIFY_TRUE_OR_RETURN(foo, -EINVAL); // just to satisfy the verifier
+ *
+ *   if (unlikely(bar))			  // normal program logic
+ *   	return XFW_CTX_DROP;
+ */
 #define VERIFY_TRUE_OR_RETURN(v, r)					\
 do {									\
 	if (unlikely(!(v))) {						\

--- a/bpf/tc.c
+++ b/bpf/tc.c
@@ -80,7 +80,7 @@ out_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey* prot_net_key, void **prot_net_map
  * Parsing function, should not drop packets!
  */
 static __always_inline int
-out_process_l4(XfwGlobalCtx *ctx, struct tcphdr **tcp_hdr)
+out_process_l4(XfwGlobalCtx *ctx)
 {
 	switch (ctx->l4_proto) {
 	case XFW_L4_PROTO_TCP: {
@@ -88,7 +88,6 @@ out_process_l4(XfwGlobalCtx *ctx, struct tcphdr **tcp_hdr)
 		if (unlikely(parse_tcphdr(&ctx->hdr_cur, &ctx->th) <= 0))
 			return XFW_MAKE_CTX_PASS(ctx, XFW_TCP_BADHDR_EGRESS);
 
-		*tcp_hdr = ctx->th;
 		/* It is a regular case, don't need to add any statistic */
 		return XFW_CTX_CONTINUE;
 	}
@@ -156,9 +155,8 @@ xfw_tc_egress_filter(struct XfwGlobalCtx *ctx, bool *is_upstream_egress)
 	ctx->ipver = ipver;
 
 	/* Build map lookup keys before policy evaluation. */
-	struct tcphdr *tcp_hdr = NULL;
 	CHAIN(out_process_l3, ctx, &prot_net_key, &prot_net_map);
-	CHAIN(out_process_l4, ctx, &tcp_hdr);
+	CHAIN(out_process_l4, ctx);
 	/* Parsing is complete; start policy checks. */
 
 	*is_upstream_egress = (bpf_map_lookup_elem(prot_net_map, &prot_net_key) == NULL);
@@ -169,7 +167,7 @@ xfw_tc_egress_filter(struct XfwGlobalCtx *ctx, bool *is_upstream_egress)
 	 * Still needs to be called when rules are not loaded. TCP AUTH filter is
 	 * atomatically inactive at that time.
 	 */
-	tcp_auth_conn_egress_learning(ctx, tcp_hdr);
+	tcp_auth_conn_egress_learning(ctx);
 
 	return XFW_CTX_PASS;
 }

--- a/bpf/tc.c
+++ b/bpf/tc.c
@@ -80,7 +80,7 @@ out_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey* prot_net_key, void **prot_net_map
  * Parsing function, should not drop packets!
  */
 static __always_inline int
-out_process_l4(XfwGlobalCtx *ctx)
+out_process_l4(XfwGlobalCtx *ctx, struct tcphdr **tcp_hdr)
 {
 	switch (ctx->l4_proto) {
 	case XFW_L4_PROTO_TCP: {
@@ -88,6 +88,7 @@ out_process_l4(XfwGlobalCtx *ctx)
 		if (unlikely(parse_tcphdr(&ctx->hdr_cur, &ctx->th) <= 0))
 			return XFW_MAKE_CTX_PASS(ctx, XFW_TCP_BADHDR_EGRESS);
 
+		*tcp_hdr = ctx->th;
 		/* It is a regular case, don't need to add any statistic */
 		return XFW_CTX_CONTINUE;
 	}
@@ -149,13 +150,15 @@ xfw_tc_egress_filter(struct XfwGlobalCtx *ctx, bool *is_upstream_egress)
 	 * dropped by the xdp.c filter.
 	 */
 
-	ctx->ipver = parse_ethhdr(&ctx->hdr_cur, &ctx->eth);
-	if (unlikely(ctx->ipver < 0))
+	int ipver = parse_ethhdr(&ctx->hdr_cur, &ctx->eth);
+	if (unlikely(ipver < 0))
 		return XFW_MAKE_CTX_PASS(ctx, XFW_ETH_BADHDR_EGRESS);
+	ctx->ipver = ipver;
 
 	/* Build map lookup keys before policy evaluation. */
+	struct tcphdr *tcp_hdr = NULL;
 	CHAIN(out_process_l3, ctx, &prot_net_key, &prot_net_map);
-	CHAIN(out_process_l4, ctx);
+	CHAIN(out_process_l4, ctx, &tcp_hdr);
 	/* Parsing is complete; start policy checks. */
 
 	*is_upstream_egress = (bpf_map_lookup_elem(prot_net_map, &prot_net_key) == NULL);
@@ -166,7 +169,7 @@ xfw_tc_egress_filter(struct XfwGlobalCtx *ctx, bool *is_upstream_egress)
 	 * Still needs to be called when rules are not loaded. TCP AUTH filter is
 	 * atomatically inactive at that time.
 	 */
-	tcp_auth_conn_egress_learning(ctx);
+	tcp_auth_conn_egress_learning(ctx, tcp_hdr);
 
 	return XFW_CTX_PASS;
 }

--- a/bpf/tcp_auth.h
+++ b/bpf/tcp_auth.h
@@ -195,12 +195,10 @@ tcp_auth_conn_ingress_filter(const XfwGlobalCtx *ctx, const XfwSockAddr *addr,
 }
 
 static __always_inline void
-tcp_auth_conn_egress_learning(const XfwGlobalCtx *ctx, struct tcphdr *th)
+tcp_auth_conn_egress_learning(const XfwGlobalCtx *ctx)
 {
-	if (!th)
-		return;
-	if (unlikely((void *)(th + 1) > ctx->hdr_cur.end))
-		return;
+	struct tcphdr *th = ctx->th;
+	VERIFY_TRUE_OR_RETURN((void *)(th + 1) <= ctx->hdr_cur.end, (void)0);
 
 	const XfwSockAddr addr = {
 		.addr = ctx->ilog_addr,

--- a/bpf/tcp_auth.h
+++ b/bpf/tcp_auth.h
@@ -195,10 +195,11 @@ tcp_auth_conn_ingress_filter(const XfwGlobalCtx *ctx, const XfwSockAddr *addr,
 }
 
 static __always_inline void
-tcp_auth_conn_egress_learning(const XfwGlobalCtx *ctx)
+tcp_auth_conn_egress_learning(const XfwGlobalCtx *ctx, struct tcphdr *th)
 {
-	struct tcphdr *th = ctx->th;
 	if (!th)
+		return;
+	if (unlikely((void *)(th + 1) > ctx->hdr_cur.end))
 		return;
 
 	const XfwSockAddr addr = {

--- a/bpf/tcp_syncookies.h
+++ b/bpf/tcp_syncookies.h
@@ -197,7 +197,7 @@ typedef struct {
  * The maximum length of options is 40 bytes (RFC 9293 3.1).
  *
  * A practical limit for TCP options would be 30: 10 x <NOP, NOP, 2 byte option>.
- * However, there are options-stripping and TCP nomalizating middleboxes
+ * However, there are options-stripping and TCP normalizing middleboxes that
  * typically just rewrite options with NOPs instead of moving the options.
  */
 #define TCP_OPTS_MAX		40
@@ -234,15 +234,6 @@ tcp_parse_one_opt(uint64_t index, void *cb_data)
 	XfwTCPOptCtx *c = cb_data;
 	const uint64_t off = c->off, opt_len = c->opt_len;
 
-	/*
-	 * The verifier widens the loop-carried state between the callback
-	 * invocations, so re-establish all the bounds from scratch on each
-	 * invocation. opt_len > TCP_OPTS_MAX is unreachable.
-	 */
-	if (unlikely(opt_len > TCP_OPTS_MAX)) {
-		c->err = -E2BIG;
-		return 1;
-	}
 	/*
 	 * This is the normal loop termination condition.
 	 * We use 1 extra step in bpf_loop() exactly to call the callback last
@@ -334,7 +325,7 @@ bad_opt:
  * continues after the loop with a single state, no matter how complex the
  * surrounding program is.
  */
-static __noinline int
+static __always_inline int
 tcp_parse_opts(XfwGlobalCtx *ctx, XfwTCPOpts *opts)
 {
 	const uint8_t *const o = (uint8_t *)ctx->th + sizeof(struct tcphdr);
@@ -619,10 +610,10 @@ tcp_syncookies_syn_filter(XfwGlobalCtx *ctx)
 	    && !tcp_syncookies_passive_mode(ctx, ts))
 		return XFW_CTX_CONTINUE;
 
-	const bool is_ip4 = (ctx->ipver == bpf_ntohs(ETH_P_IP));
-	void *iph = is_ip4 ? (void *)ctx->iph4 : (void *)ctx->iph6;
-	uint32_t iph_len = is_ip4 ? sizeof(struct iphdr) : sizeof(struct ipv6hdr);
-	XFW_ASSERT(iph && iph + iph_len <= ctx->hdr_cur.end);
+	uint32_t iph_len = ctx->ipver == bpf_ntohs(ETH_P_IP)
+			   ? sizeof(struct iphdr)
+			   : sizeof(struct ipv6hdr);
+	XFW_ASSERT(ctx->iph && ctx->iph + iph_len <= ctx->hdr_cur.end);
 
 	/*
 	 * The kernel syncookie helper expects a minimal SYN header. Temporarily
@@ -643,7 +634,7 @@ tcp_syncookies_syn_filter(XfwGlobalCtx *ctx)
 					 "No listening socket");
 	}
 
-	int64_t seq_mss = bpf_tcp_gen_syncookie(sk, iph, iph_len, ctx->th,
+	int64_t seq_mss = bpf_tcp_gen_syncookie(sk, ctx->iph, iph_len, ctx->th,
 						sizeof(struct tcphdr));
 	bpf_sk_release(sk);
 	ctx->th->doff = old_doff & 0xF;
@@ -723,10 +714,8 @@ tcp_syncookies_ack_filter(const XfwGlobalCtx *ctx)
 				"IPv4 ACK with invalid cookie, retcode=%d.", r);
 	}
 	else if (ctx->ipver == bpf_ntohs(ETH_P_IPV6)) {
-		VERIFY_TRUE_OR_RETURN((void *)(ctx->iph6 + 1) <= ctx->hdr_cur.end,
-				      XFW_CTX_DROP);
-		VERIFY_TRUE_OR_RETURN((void *)(ctx->th + 1) <= ctx->hdr_cur.end,
-				      XFW_CTX_DROP);
+		/* This check is just to satisfy the verifier. */
+		XFW_ASSERT((void *)(ctx->iph6 + 1) <= ctx->hdr_cur.end);
 
 		int r = bpf_tcp_raw_check_syncookie_ipv6(ctx->iph6, ctx->th);
 		if (r < 0)

--- a/bpf/tcp_syncookies.h
+++ b/bpf/tcp_syncookies.h
@@ -194,95 +194,185 @@ typedef struct {
 } XfwTCPOpts;
 
 /*
+ * The maximum length of options is 40 bytes (RFC 9293 3.1).
+ *
+ * A practical limit for TCP options would be 30: 10 x <NOP, NOP, 2 byte option>.
+ * However, there are options-stripping and TCP nomalizating middleboxes
+ * typically just rewrite options with NOPs instead of moving the options.
+ */
+#define TCP_OPTS_MAX		40
+/*
+ * The parsing buffer is a bit larger than the options area, so the verifier
+ * can prove in-bounds access for all option value reads knowing only that
+ * the option offset is less than TCP_OPTS_MAX: the largest access is a 4-byte
+ * timestamp value read at offset 39 (kind) + 2 (option header) = 45. Use 48
+ * as the smallest 8-byte alignment.
+ */
+#define TCP_OPTS_BUF_SZ		48
+
+typedef struct {
+	uint8_t			buf[TCP_OPTS_BUF_SZ];
+	XfwTCPOpts		*opts;
+	const uint64_t		opt_len;
+	uint64_t		off;
+	int			err;
+} XfwTCPOptCtx;
+
+/**
+ * Parse a single TCP option from the stack buffer @c->buf.
+ *
+ * All the offset arithmetic is 64-bit: with 32-bit types clang zero-extends
+ * values with the '<<= 32; >>= 32' shift pairs in separate registers, so the
+ * verifier refines the bounds of the zero-extended copy, but sees the
+ * original register, used in the buffer access, as unbounded.
+ *
+ * @return 0 to continue the loop, 1 to stop it (@c->err holds the result).
+ */
+static long
+tcp_parse_one_opt(uint64_t index, void *cb_data)
+{
+	XfwTCPOptCtx *c = cb_data;
+	const uint64_t off = c->off, opt_len = c->opt_len;
+
+	/*
+	 * The verifier widens the loop-carried state between the callback
+	 * invocations, so re-establish all the bounds from scratch on each
+	 * invocation. opt_len > TCP_OPTS_MAX is unreachable.
+	 */
+	if (unlikely(opt_len > TCP_OPTS_MAX)) {
+		c->err = -E2BIG;
+		return 1;
+	}
+	/*
+	 * This is the normal loop termination condition.
+	 * We use 1 extra step in bpf_loop() exactly to call the callback last
+	 * time and return with zero error code on reaching end of data.
+	 */
+	if (off >= opt_len) {
+		c->err = 0;
+		return 1;
+	}
+
+	/* The first byte is the kind of the option. */
+	const uint8_t kind = c->buf[off];
+
+	if (kind == TCPOPT_EOL) {
+		/*
+		 * If non zero values are present after EOL, then the
+		 * segment is anomalous (RFC 9293 3).
+		 * Do not read out all trailing zeros at the moment due
+		 * to performance reasons - maybe we should add this for
+		 * the TCP anomaly filter.
+		 */
+		c->err = 0;
+		return 1;
+	}
+	if (kind == TCPOPT_NOP) {
+		c->off = off + 1;
+		return 0;
+	}
+
+	/*
+	 * All other options carry the length in the second byte (RFC 9293 3.1)
+	 * and must fit into the options area.
+	 */
+	if (unlikely(off + 2 > opt_len))
+		goto bad_opt;
+
+	const uint64_t len = c->buf[off + 1];
+	if (unlikely(len < 2 || off + len > opt_len))
+		goto bad_opt;
+
+	switch (kind) {
+	case TCPOPT_WSCALE: {
+		/* RFC 7323 2.2: kind, len=3, 1 byte val. */
+		if (unlikely(len != TCPOPT_WSCALE_SZ))
+			goto bad_opt;
+		const uint8_t ws = c->buf[off + 2];
+		/* RFC 7323 2.3: values above 14 are capped to 14. */
+		c->opts->wscale = ws <= TCPOPT_WSCALE_MAX
+				  ? ws : TCPOPT_WSCALE_MAX;
+		break;
+	}
+	case TCPOPT_SACK_PERM:
+		/* RFC 2018 2: kind, len=2. */
+		if (unlikely(len != TCPOPT_SACK_PERM_SZ))
+			goto bad_opt;
+		c->opts->sack_perm = 1;
+		break;
+	case TCPOPT_TIMESTAMP:
+		/*
+		 * RFC 7323 3.2:
+		 * kind, len=10, TS val 4 bytes, TS echo 4 bytes.
+		 */
+		if (unlikely(len != TCPOPT_TIMESTAMP_SZ))
+			goto bad_opt;
+		/* RFC 7323 4.3: ignore duplicate timestamp options. */
+		if (likely(!c->opts->ts))
+			c->opts->ts = get_unaligned((__be32 *)&c->buf[off + 2]);
+		break;
+	}
+
+	c->off = off + len;
+	return 0;
+
+bad_opt:
+	c->err = -EINVAL;
+	return 1;
+}
+
+/*
  * Parse TCP Options, RFC 9293 chapter 3.
  *
  * RFC does not specify what to do with duplicate MSS, Window Scale and SACK
  * Permited options, so for now we just use the last one for simplicity.
  * This can be added to the TCP anomaly filter later.
+ *
+ * The options are copied to a zeroed stack buffer and parsed from the stack,
+ * one option per bpf_loop() iteration. This way the verifier proves the
+ * parsing loop in isolation, converging on the widened loop state, and
+ * continues after the loop with a single state, no matter how complex the
+ * surrounding program is.
  */
 static __noinline int
 tcp_parse_opts(XfwGlobalCtx *ctx, XfwTCPOpts *opts)
 {
-	const uint8_t *e, *const o = (uint8_t *)ctx->th + sizeof(struct tcphdr);
-	const uint8_t *const o_end = (uint8_t *)ctx->th + ctx->th->doff * 4;
-	const uint8_t *const d_end = (uint8_t *)ctx->hdr_cur.end;
+	const uint8_t *const o = (uint8_t *)ctx->th + sizeof(struct tcphdr);
+	const uint64_t th_len = ctx->th->doff * 4;
 
-	/* The maximum length of options is 40 bytes (RFC 9293 3.1). */
-	VERIFY_TRUE_OR_RETURN(o + 40 >= o_end, -E2BIG);
+	VERIFY_TRUE_OR_RETURN(th_len >= sizeof(struct tcphdr), -EINVAL);
+	const uint64_t opt_len = th_len - sizeof(struct tcphdr);
+	VERIFY_TRUE_OR_RETURN(opt_len <= TCP_OPTS_MAX, -E2BIG);
+	if (unlikely(opt_len == 0))
+		return 0;
 
-	uint8_t i, off = 0;
-	bpf_for (i, 0, 40) {
-		if (o + off >= o_end || unlikely(o + off >= d_end))
-			return 0;
+	XfwTCPOptCtx c = {
+		.buf		= {0},
+		.opts		= opts,
+		.opt_len	= opt_len,
+		.off		= 0,
+		/* Reaching the iterations limit isn't normal. */
+		.err		= -E2BIG,
+	};
 
-		/* First byte is kind of the option. */
-		switch (o[off]) {
-		case TCPOPT_EOL:
-			/*
-			 * If non zero values are present after EOL, then the
-			 * segment is anomalous (RFC 9293 3).
-			 * Do not read out all trailing zeros at the moment due
-			 * to performance reasons - maybe we should add this for
-			 * the TCP anomaly filter.
-			 */
-			return 0;
+	/*
+	 * Copy the options to the parsing buffer. The helper validates the
+	 * packet bounds, so a truncated packet ends up with -EINVAL.
+	 */
+	const uint64_t opt_off = (void *)o - XFW_CTX_DATA_BGN(ctx->ctx);
+	if (unlikely(bpf_xdp_load_bytes(ctx->ctx, opt_off, c.buf, opt_len)))
+		return -EINVAL;
 
-		case TCPOPT_NOP:
-			++off;
-			continue;
+	/*
+	 * One option per iteration: TCP_OPTS_MAX + 1 iterations guarantee
+	 * that the terminal check in the callback is reached even for
+	 * TCP_OPTS_MAX one-byte options.
+	 */
+	long r = bpf_loop(TCP_OPTS_MAX + 1, tcp_parse_one_opt, &c, 0);
+	if (unlikely(r < 0))
+		return r;
 
-		case TCPOPT_WSCALE:
-			/* RFC 7323 2.2: kind, len=3, 1 byte val */
-			e = o + off + TCPOPT_WSCALE_SZ;
-			VERIFY_TRUE_OR_RETURN(e <= o_end && e <= d_end, -EINVAL);
-			VERIFY_TRUE_OR_RETURN(o[off + 1] == TCPOPT_WSCALE_SZ, -EINVAL);
-			opts->wscale = o[off + 2];
-			VERIFY_TRUE_OR_RETURN(o[off + 2] <= TCPOPT_WSCALE_MAX, -EINVAL);
-			off += TCPOPT_WSCALE_SZ;
-			continue;
-
-		case TCPOPT_SACK_PERM:
-			/* RFC 2018 2: kind, len=2 */
-			e = o + off + TCPOPT_SACK_PERM_SZ;
-			VERIFY_TRUE_OR_RETURN(e <= o_end && e <= d_end, -EINVAL);
-			VERIFY_TRUE_OR_RETURN(o[off + 1] == TCPOPT_SACK_PERM_SZ,
-					      -EINVAL);
-			opts->sack_perm = 1;
-			off += TCPOPT_SACK_PERM_SZ;
-			continue;
-
-		case TCPOPT_TIMESTAMP:
-			/*
-			 * RFC 7323 3.2:
-			 * kind, len=10, TS val 4 bytes, TS echo (tsecr) 4 bytes
-			 */
-			e = o + off + TCPOPT_TIMESTAMP_SZ;
-			VERIFY_TRUE_OR_RETURN(e <= o_end && e <= d_end, -EINVAL);
-			VERIFY_TRUE_OR_RETURN(o[off + 1] == TCPOPT_TIMESTAMP_SZ, -EINVAL);
-			/* RFC 7323 4.3: ignore duplicate timestamp options. */
-			if (likely(!opts->ts))
-				opts->ts = get_unaligned((__be32 *)(o + off + 2));
-			off += TCPOPT_TIMESTAMP_SZ;
-			continue;
-
-		default:
-			/*
-			 * Generic processing of other options.
-			 * Only NOP and EOL have 1 byte lengh, all others must
-			 * have length field (RFC 9293 3.1).
-			 */
-			e = o + off + 2;
-			VERIFY_TRUE_OR_RETURN(e <= o_end && e <= d_end, -EINVAL);
-			uint8_t olen = o[off + 1];
-			VERIFY_TRUE_OR_RETURN(olen >= 2, -EINVAL);
-			e = o + off + olen;
-			VERIFY_TRUE_OR_RETURN(e <= o_end && e <= d_end, -EINVAL);
-			off += olen;
-			continue;
-		}
-	}
-
-	return 0;
+	return c.err;
 }
 
 /**

--- a/bpf/tcp_syncookies.h
+++ b/bpf/tcp_syncookies.h
@@ -445,7 +445,7 @@ tcp_syncookies_make_synack(XfwGlobalCtx *ctx, uint32_t cookie, uint16_t mss,
 	memcpy(ctx->eth->h_dest, tmp_eth.h_source, sizeof(tmp_eth.h_source));
 	memcpy(ctx->eth->h_source, tmp_eth.h_dest, sizeof(tmp_eth.h_dest));
 
-	if (ctx->iph4) {
+	if (ctx->ipver == bpf_ntohs(ETH_P_IP)) {
 		uint64_t ip_csum = csum_unfold(ctx->iph4->check);
 		uint16_t ip_len = bpf_ntohs(ctx->iph4->tot_len) + d_len;
 		ipv4_set_ttl_csum(ctx, &ip_csum);
@@ -457,7 +457,9 @@ tcp_syncookies_make_synack(XfwGlobalCtx *ctx, uint32_t cookie, uint16_t mss,
 
 		tcp_ipv4_csum_update(ctx, csum);
 	}
-	else if (ctx->iph6) {
+	else if (ctx->ipver == bpf_ntohs(ETH_P_IPV6)) {
+		VERIFY_TRUE_OR_RETURN((void *)(ctx->iph6 + 1) <= ctx->hdr_cur.end,
+				      -EINVAL);
 		ctx->iph6->hop_limit = XFW_DEFAULT_TTL;
 		uint16_t payload_len = bpf_ntohs(ctx->iph6->payload_len);
 		ctx->iph6->payload_len = bpf_htons(payload_len + d_len);
@@ -487,14 +489,16 @@ tcp_sk_listen_lookup(const XfwGlobalCtx *ctx)
 	struct bpf_sock_tuple t;
 	size_t tlen;
 
-	if (ctx->iph4) {
+	if (ctx->ipver == bpf_ntohs(ETH_P_IP)) {
 		tlen = sizeof(t.ipv4);
 		t.ipv4.sport = ctx->th->source;
 		t.ipv4.dport = ctx->th->dest;
 		t.ipv4.saddr = ctx->iph4->saddr;
 		t.ipv4.daddr = ctx->iph4->daddr;
 	}
-	else if (ctx->iph6) {
+	else if (ctx->ipver == bpf_ntohs(ETH_P_IPV6)) {
+		VERIFY_TRUE_OR_RETURN((void *)(ctx->iph6 + 1) <= ctx->hdr_cur.end,
+				      NULL);
 		tlen = sizeof(t.ipv6);
 		t.ipv6.sport = ctx->th->source;
 		t.ipv6.dport = ctx->th->dest;
@@ -525,7 +529,7 @@ tcp_syncookies_syn_filter(XfwGlobalCtx *ctx)
 	    && !tcp_syncookies_passive_mode(ctx, ts))
 		return XFW_CTX_CONTINUE;
 
-	const bool is_ip4 = ctx->iph4 != NULL;
+	const bool is_ip4 = (ctx->ipver == bpf_ntohs(ETH_P_IP));
 	void *iph = is_ip4 ? (void *)ctx->iph4 : (void *)ctx->iph6;
 	uint32_t iph_len = is_ip4 ? sizeof(struct iphdr) : sizeof(struct ipv6hdr);
 	XFW_ASSERT(iph && iph + iph_len <= ctx->hdr_cur.end);
@@ -622,12 +626,18 @@ tcp_syncookies_ack_filter(const XfwGlobalCtx *ctx)
 	 * API backward compatibility. Reference:
 	 * https://groups.google.com/g/clang-built-linux/c/Ehb-mZnip-E/m/nRWGW24PBAAJ
 	 */
-	if (ctx->iph4) {
+	if (ctx->ipver == bpf_ntohs(ETH_P_IP)) {
 		int r = bpf_tcp_raw_check_syncookie_ipv4(ctx->iph4, ctx->th);
 		if (r < 0)
 			return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_SYNCOOKIE_FAILED,
 				"IPv4 ACK with invalid cookie, retcode=%d.", r);
-	} else if (ctx->iph6) {
+	}
+	else if (ctx->ipver == bpf_ntohs(ETH_P_IPV6)) {
+		VERIFY_TRUE_OR_RETURN((void *)(ctx->iph6 + 1) <= ctx->hdr_cur.end,
+				      XFW_CTX_DROP);
+		VERIFY_TRUE_OR_RETURN((void *)(ctx->th + 1) <= ctx->hdr_cur.end,
+				      XFW_CTX_DROP);
+
 		int r = bpf_tcp_raw_check_syncookie_ipv6(ctx->iph6, ctx->th);
 		if (r < 0)
 			return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_SYNCOOKIE_FAILED,

--- a/bpf/tcp_syncookies.h
+++ b/bpf/tcp_syncookies.h
@@ -207,16 +207,16 @@ tcp_parse_opts(XfwGlobalCtx *ctx, XfwTCPOpts *opts)
 	const uint8_t *const o_end = (uint8_t *)ctx->th + ctx->th->doff * 4;
 	const uint8_t *const d_end = (uint8_t *)ctx->hdr_cur.end;
 
-	/* The maximum lenght of options is 40 bytes (RFC 9293 3.1). */
+	/* The maximum length of options is 40 bytes (RFC 9293 3.1). */
 	VERIFY_TRUE_OR_RETURN(o + 40 >= o_end, -E2BIG);
 
-	uint8_t i;
+	uint8_t i, off = 0;
 	bpf_for (i, 0, 40) {
-		if (o + i >= o_end || unlikely(o + i >= d_end))
+		if (o + off >= o_end || unlikely(o + off >= d_end))
 			return 0;
 
 		/* First byte is kind of the option. */
-		switch (o[i]) {
+		switch (o[off]) {
 		case TCPOPT_EOL:
 			/*
 			 * If non zero values are present after EOL, then the
@@ -228,27 +228,27 @@ tcp_parse_opts(XfwGlobalCtx *ctx, XfwTCPOpts *opts)
 			return 0;
 
 		case TCPOPT_NOP:
-			++i;
+			++off;
 			continue;
 
 		case TCPOPT_WSCALE:
 			/* RFC 7323 2.2: kind, len=3, 1 byte val */
-			e = o + i + TCPOPT_WSCALE_SZ;
+			e = o + off + TCPOPT_WSCALE_SZ;
 			VERIFY_TRUE_OR_RETURN(e <= o_end && e <= d_end, -EINVAL);
-			VERIFY_TRUE_OR_RETURN(o[i + 1] == TCPOPT_WSCALE_SZ, -EINVAL);
-			opts->wscale = o[i + 2];
-			VERIFY_TRUE_OR_RETURN(o[i] <= TCPOPT_WSCALE_MAX, -EINVAL);
-			i += TCPOPT_WSCALE_SZ;
+			VERIFY_TRUE_OR_RETURN(o[off + 1] == TCPOPT_WSCALE_SZ, -EINVAL);
+			opts->wscale = o[off + 2];
+			VERIFY_TRUE_OR_RETURN(o[off + 2] <= TCPOPT_WSCALE_MAX, -EINVAL);
+			off += TCPOPT_WSCALE_SZ;
 			continue;
 
 		case TCPOPT_SACK_PERM:
 			/* RFC 2018 2: kind, len=2 */
-			e = o + i + TCPOPT_SACK_PERM_SZ;
+			e = o + off + TCPOPT_SACK_PERM_SZ;
 			VERIFY_TRUE_OR_RETURN(e <= o_end && e <= d_end, -EINVAL);
-			VERIFY_TRUE_OR_RETURN(o[i + 1] == TCPOPT_SACK_PERM_SZ,
+			VERIFY_TRUE_OR_RETURN(o[off + 1] == TCPOPT_SACK_PERM_SZ,
 					      -EINVAL);
 			opts->sack_perm = 1;
-			i += TCPOPT_SACK_PERM_SZ;
+			off += TCPOPT_SACK_PERM_SZ;
 			continue;
 
 		case TCPOPT_TIMESTAMP:
@@ -256,13 +256,13 @@ tcp_parse_opts(XfwGlobalCtx *ctx, XfwTCPOpts *opts)
 			 * RFC 7323 3.2:
 			 * kind, len=10, TS val 4 bytes, TS echo (tsecr) 4 bytes
 			 */
-			e = o + i + TCPOPT_TIMESTAMP_SZ;
+			e = o + off + TCPOPT_TIMESTAMP_SZ;
 			VERIFY_TRUE_OR_RETURN(e <= o_end && e <= d_end, -EINVAL);
-			VERIFY_TRUE_OR_RETURN(o[i + 1] == TCPOPT_TIMESTAMP_SZ, -EINVAL);
+			VERIFY_TRUE_OR_RETURN(o[off + 1] == TCPOPT_TIMESTAMP_SZ, -EINVAL);
 			/* RFC 7323 4.3: ignore duplicate timestamp options. */
 			if (likely(!opts->ts))
-				opts->ts = get_unaligned((__be32 *)(o + i + 2));
-			i += TCPOPT_TIMESTAMP_SZ;
+				opts->ts = get_unaligned((__be32 *)(o + off + 2));
+			off += TCPOPT_TIMESTAMP_SZ;
 			continue;
 
 		default:
@@ -271,13 +271,13 @@ tcp_parse_opts(XfwGlobalCtx *ctx, XfwTCPOpts *opts)
 			 * Only NOP and EOL have 1 byte lengh, all others must
 			 * have length field (RFC 9293 3.1).
 			 */
-			e = o + i + 2;
+			e = o + off + 2;
 			VERIFY_TRUE_OR_RETURN(e <= o_end && e <= d_end, -EINVAL);
-			uint8_t olen = o[i + 1];
+			uint8_t olen = o[off + 1];
 			VERIFY_TRUE_OR_RETURN(olen >= 2, -EINVAL);
-			e = o + i + olen;
+			e = o + off + olen;
 			VERIFY_TRUE_OR_RETURN(e <= o_end && e <= d_end, -EINVAL);
-			i += olen;
+			off += olen;
 			continue;
 		}
 	}

--- a/bpf/xdp.c
+++ b/bpf/xdp.c
@@ -161,7 +161,7 @@ icmp_filter(const XfwGlobalCtx *ctx, const XfwIcmpKey *key)
 }
 
 static __always_inline uint8_t
-src_port_default_by_protos(int ipver, uint8_t l4_proto)
+src_port_default_by_protos(uint16_t ipver, uint8_t l4_proto)
 {
 	if (ipver == bpf_ntohs(ETH_P_IP)) {
 		if (l4_proto == XFW_L4_PROTO_TCP) {
@@ -667,9 +667,10 @@ xfw_xdp_filter(struct XfwGlobalCtx *ctx)
 		return XFW_MAKE_CTX_PASS(ctx, XFW_PRELOAD_INGRESS);
 	}
 
-	ctx->ipver = parse_ethhdr(&ctx->hdr_cur, &ctx->eth);
-	if (unlikely(ctx->ipver < 0))
+	int ipver = parse_ethhdr(&ctx->hdr_cur, &ctx->eth);
+	if (unlikely(ipver < 0))
 		return XFW_MAKE_CTX_DROP(ctx, XFW_ETH_BADHDR_INGRESS);
+	ctx->ipver = ipver;
 
 	int r;
 	/* Helper structure for src filter, filled on L3, used on L4. */

--- a/doc/perf.md
+++ b/doc/perf.md
@@ -77,8 +77,8 @@ PREFIX=/root/ak/xfw_install/ make install
 1. [Start xFW](/Basic-Administration/#run-amp-stop) and load configuration. It's
    useful to run xFW from a local (`main`) build:
 ```
-XFW_PATH=~/ak/xfw_install/ TFW_CFG_FILE=~/ak/xfw.json ~/ak/xfw_install/bin/xfwctl --start
-XFW_PATH=~/ak/xfw_install/ TFW_CFG_FILE=~/ak/xfw.json ~/ak/xfw_install/bin/xfwctl --status
+TEMPESTA_XFW_PATH=~/ak/xfw_install/ TFW_CFG_FILE=~/ak/xfw.json ~/ak/xfw_install/bin/xfwctl --start
+TEMPESTA_XFW_PATH=~/ak/xfw_install/ TFW_CFG_FILE=~/ak/xfw.json ~/ak/xfw_install/bin/xfwctl --status
 ```
 
 2. Load rules, e.g.

--- a/doc/perf.md
+++ b/doc/perf.md
@@ -71,14 +71,14 @@ CC=gcc-10 CXX=g++-10 ./b build
 
 0. Install xFW by a custom path:
 ```
-PREFIX=/root/ak/escudo_install/ make install
+PREFIX=/root/ak/xfw_install/ make install
 ```
 
 1. [Start xFW](/Basic-Administration/#run-amp-stop) and load configuration. It's
    useful to run xFW from a local (`main`) build:
 ```
-ESCUDO_PATH=~/ak/escudo_install/ TFW_CFG_FILE=~/ak/xfw.json ~/ak/escudo_install/bin/xfwctl --start
-ESCUDO_PATH=~/ak/escudo_install/ TFW_CFG_FILE=~/ak/xfw.json ~/ak/escudo_install/bin/xfwctl --status
+XFW_PATH=~/ak/xfw_install/ TFW_CFG_FILE=~/ak/xfw.json ~/ak/xfw_install/bin/xfwctl --start
+XFW_PATH=~/ak/xfw_install/ TFW_CFG_FILE=~/ak/xfw.json ~/ak/xfw_install/bin/xfwctl --status
 ```
 
 2. Load rules, e.g.
@@ -101,7 +101,17 @@ ESCUDO_PATH=~/ak/escudo_install/ TFW_CFG_FILE=~/ak/xfw.json ~/ak/escudo_install/
 
 ## Configure Generator
 
-1. (Optional) change MTU. TRex optimizes throughput via big frames, but we need normal traffic to
+1. Make the kernel to allocate gigantic pages in `/etc/default/grub`
+```
+GRUB_CMDLINE_LINUX="spectre_v2=off ibrs=off hugepage_size=1g hugepages=16"
+```
+and enable 8 huge pages on each of the nodes:
+```
+echo 8 > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages
+echo 8 > /sys/devices/system/node/node1/hugepages/hugepages-1048576kB/nr_hugepages
+```
+
+2. (Optional) change MTU. TRex optimizes throughput via big frames, but we need normal traffic to
 emulate real workloads:
 ```
 git diff
@@ -121,21 +131,21 @@ index bc7003de2..646c15909 100755
              self.set_mtu_mlx(dev_id,mtu);
 ```
 
-2. Determine NIC ports' PCI IDs:
+3. Determine NIC ports' PCI IDs:
 ```
 lspci |grep 'ConnectX-6 Dx'
 98:00.0 Ethernet controller: Mellanox Technologies MT2892 Family [ConnectX-6 Dx]
 98:00.1 Ethernet controller: Mellanox Technologies MT2892 Family [ConnectX-6 Dx]
 ```
 
-3. Copy TRex config amd adjust NIC ports in it if necessary:
+4. Copy TRex config amd adjust NIC ports in it if necessary:
 ```
 cp ~/xFW/t/trex/trex_cfg.yaml /etc
 ```
 
 > Dummy interfaces allow to use both ports for sending packets, and non of them for receiving.
 
-4. If you have Python > 3.11 (Ubuntu 24):
+5. If you have Python > 3.11 (Ubuntu 24):
 
 Ubuntu 24 is shipped with Python 3.12, so TRex doesn't work out of the box due to legacy Scapy
 module and you need to install Python 3.11:
@@ -165,17 +175,14 @@ You can remove `venv` just removing the directory:
 rm -rf venv
 ```
 
-5. Prepare TRex:
+6. Prepare TRex:
 ```
 cd /trex/trex-core/scripts
 sudo -i
 source ./venv/bin/activate
 ./trex-cfg
 apt install -y dpdk
-dpdk-hugepages.py --setup 2G
 ```
-
-TODO: address 2G hugepages - it seems boot setup is more efficient
 
 > Reboot the server if you see error message like:
 ```
@@ -206,7 +213,7 @@ For traffic performance statistics use `bmon` or `dstat`, e.g.
 bmon -p 'enp202s0f*'
 ```
 ```
-dstat --cpu-adv --net -N enp202s0f1np1 -N enp202s0f0np0 --net-packets --sys --bits --time --int -I RES
+dstat --cpu-adv --net -N enp202s0f1np1,enp202s0f0np0 --net-packets --sys --time --int -I RES
 ```
 
 Also `htop` is good to observe CPU utilization.

--- a/xfwctl
+++ b/xfwctl
@@ -304,6 +304,41 @@ load_xdp()
 	echo "$pinned_path" >> "$pin_dispatchers_log"
 }
 
+load_tc()
+{
+	local dev="$1"
+
+	mkdir -p /tmp/tempesta/xfw
+	local tmp_log=$(mktemp /tmp/tempesta/xfw/tc-loader.XXXXXX)
+
+	# Create a TC hook to attach by xFW TC program.
+	# The hook might be configured by somebody else, so check it first.
+	#
+	# TODO #10: replace the legacy tc calls with a
+	# bpf_program__attach_tcx() program.
+	if ! tc qdisc show dev "$dev" | grep -q clsact; then
+		tc qdisc add dev "$dev" clsact || {
+			unload_bpf
+			error "Failed to add clsact qdisc on $dev"
+		}
+	fi
+
+	[ $v -eq 1 ] && echo tc filter add dev "$dev" egress bpf da obj "$project_path/lib/bpf/tc.o" sec tc
+
+	tc filter add dev "$dev" egress bpf da obj "$project_path/lib/bpf/tc.o" sec tc > "$tmp_log" 2>&1
+	local rc=$?
+	if [ $rc -ne 0 ]; then
+		echo "Error while loading TC program. See $tmp_log for details."
+		[ $v -eq 1 ] && echo "Trying to unload rest bpf programs:"
+		unload_bpf
+		[ $v -eq 1 ] && echo ""
+		error "Failed to load TC program on device $dev (exit code $rc)"
+	fi
+
+	[ $v -eq 1 ] && echo -n "tc result: "
+	[ $v -eq 1 ] && tail -n 1 "$tmp_log"
+}
+
 load_bpf()
 {
 	mkdir -p "$xfw_bpf_path"
@@ -341,26 +376,7 @@ load_bpf()
 			error "Some eBPF programs are still loaded(TC on $dev). Please run 'xfwctl --stop'. If the problem persists, reboot the system or reload the network interface."
 		fi
 
-		# Create a TC hook to attach by xFW TC program.
-		# The hook might be configured by somebody else, so check it first.
-		#
-		# TODO #10: replace the legacy tc calls with a
-		# bpf_program__attach_tcx() program.
-		if ! tc qdisc show dev "$dev" | grep -q clsact; then
-			tc qdisc add dev $dev clsact || {
-				unload_bpf
-				error "Failed to add clsact qdisc on $dev"
-			}
-		fi
-		tc filter add dev $dev egress bpf da obj "$project_path/lib/bpf/tc.o" sec tc
-		local rc=$?
-		if [ $rc -ne 0 ]; then
-			echo "Error while loading TC program"
-			[ $v -eq 1 ] && echo "Trying to unload rest bpf programs:"
-			unload_bpf
-			[ $v -eq 1 ] && echo ""
-			error "Failed to load TC program on device $dev (exit code $rc)"
-		fi
+		load_tc $dev
 	done
 
 	bpf_maps_check error

--- a/xfwctl
+++ b/xfwctl
@@ -335,8 +335,10 @@ load_tc()
 		error "Failed to load TC program on device $dev (exit code $rc)"
 	fi
 
-	[ $v -eq 1 ] && echo -n "tc result: "
-	[ $v -eq 1 ] && tail -n 1 "$tmp_log"
+	# tc is silent on success, so the log is usually empty.
+	[ $v -eq 1 ] && [ -s "$tmp_log" ] \
+		&& echo "tc result: $(tail -n 1 "$tmp_log")"
+	rm -f "$tmp_log"
 }
 
 load_bpf()


### PR DESCRIPTION
Apply patches #29 and #31 .

After the patches eBPF verifier stopped to accept the TCP options parsing, so I had to completely rewrite the options parser.

More stack size reduction.

Also a small updates on the documentation after movement xFW from the Escudo repo.