### PR TITLE
refactoring: defer XfwDstKey and XfwSockAddr initialization.

### DIFF
--- a/bpf/dst.h
+++ b/bpf/dst.h
@@ -19,50 +19,35 @@
 SHADOW_MAP(MAP_DST_BASENAME, BPF_MAP_TYPE_HASH, XFW_MAX_DST_RULES, XfwDstKey,
 	    XfwActionRule, 0);
 
-static __always_inline void
-ipv4_populate_dst_key(const struct iphdr *ip4_hdr, int l4_proto,
-	XfwDstKey *dst_key)
-{
-	dst_key->ipver = XFW_IP_VER_4;
-	dst_key->proto = (uint8_t)l4_proto;
-	xfw_ipv4_to_ipv6_mapped(ip4_hdr->daddr, dst_key->addr.addr32);
-}
-
-static __always_inline void
-ipv6_populate_dst_key(const struct ipv6hdr *ip6_hdr, int l4_proto,
-	XfwDstKey *dst_key)
-{
-	dst_key->ipver = XFW_IP_VER_6;
-	dst_key->proto = (uint8_t)l4_proto;
-	dst_key->addr.in6 = ip6_hdr->daddr;
-}
-
 static __always_inline bool
 populate_dst_info(const XfwGlobalCtx *ctx, XfwDstKey *key, __u8 *default_idx)
 {
-	if (ctx->th) {
-		key->port = ctx->th->dest;
-		if (ctx->iph4) {
-			ipv4_populate_dst_key(ctx->iph4, ctx->l4_proto, key);
+	key->proto = (uint8_t)ctx->l4_proto;
+	if (ctx->iph4) {
+		key->ipver = XFW_IP_VER_4;
+		xfw_ipv4_to_ipv6_mapped(ctx->iph4->daddr, key->addr.addr32);
+		if (ctx->th) {
+			key->port = ctx->th->dest;
 			*default_idx = XFW_DEFAULT_DST_TCP_IP4;
 			return true;
 		}
-		if (ctx->iph6) {
-			ipv6_populate_dst_key(ctx->iph6, ctx->l4_proto, key);
-			*default_idx = XFW_DEFAULT_DST_TCP_IP6;
+		if (ctx->uh) {
+			key->port = ctx->uh->dest;
+			*default_idx = XFW_DEFAULT_DST_UDP_IP4;
 			return true;
 		}
 		return false;
 	}
-	if (ctx->uh) {
-		key->port = ctx->uh->dest;
-		if (ctx->iph4) {
-			ipv4_populate_dst_key(ctx->iph4, ctx->l4_proto, key);
-			*default_idx = XFW_DEFAULT_DST_UDP_IP4;
+	if (ctx->iph6) {
+		key->ipver = XFW_IP_VER_6;
+		key->addr.in6 = ctx->iph6->daddr;
+		if (ctx->th) {
+			key->port = ctx->th->dest;
+			*default_idx = XFW_DEFAULT_DST_TCP_IP6;
 			return true;
 		}
-		if (ctx->iph6) {
-			ipv6_populate_dst_key(ctx->iph6, ctx->l4_proto, key);
+		if (ctx->uh) {
+			key->port = ctx->uh->dest;
 			*default_idx = XFW_DEFAULT_DST_UDP_IP6;
 			return true;
 		}

--- a/bpf/dst.h
+++ b/bpf/dst.h
@@ -19,48 +19,73 @@
 SHADOW_MAP(MAP_DST_BASENAME, BPF_MAP_TYPE_HASH, XFW_MAX_DST_RULES, XfwDstKey,
 	    XfwActionRule, 0);
 
-static __always_inline uint8_t
-xfw_dst_default_by_key(const XfwDstKey *dst_key)
+static __always_inline void
+ipv4_populate_dst_key(const struct iphdr *ip4_hdr, int l4_proto,
+	XfwDstKey *dst_key)
 {
-	uint8_t dst_default;
+	dst_key->ipver = XFW_IP_VER_4;
+	dst_key->proto = (uint8_t)l4_proto;
+	xfw_ipv4_to_ipv6_mapped(ip4_hdr->daddr, dst_key->addr.addr32);
+}
 
-	/*
-	 * XfwDstKey::ipver uses XFW_IP_VER_4/6. This differs from
-	 * XfwGlobalCtx::ipver, which stores ETH_P_IP/ETH_P_IPV6.
-	 */
-	if (dst_key->ipver == XFW_IP_VER_4) {
-		if (dst_key->proto == XFW_L4_PROTO_TCP) {
-			dst_default = XFW_DEFAULT_DST_TCP_IP4;
-		} else {
-			/* XFW_L4_PROTO_UDP */
-			dst_default = XFW_DEFAULT_DST_UDP_IP4;
+static __always_inline void
+ipv6_populate_dst_key(const struct ipv6hdr *ip6_hdr, int l4_proto,
+	XfwDstKey *dst_key)
+{
+	dst_key->ipver = XFW_IP_VER_6;
+	dst_key->proto = (uint8_t)l4_proto;
+	dst_key->addr.in6 = ip6_hdr->daddr;
+}
+
+static __always_inline bool
+populate_dst_info(const XfwGlobalCtx *ctx, XfwDstKey *key, __u8 *default_idx)
+{
+	if (ctx->th) {
+		key->port = ctx->th->dest;
+		if (ctx->iph4) {
+			ipv4_populate_dst_key(ctx->iph4, ctx->l4_proto, key);
+			*default_idx = XFW_DEFAULT_DST_TCP_IP4;
+			return true;
 		}
-	} else {
-		/* ETH_P_IPV6 */
-		if (dst_key->proto == XFW_L4_PROTO_TCP) {
-			dst_default = XFW_DEFAULT_DST_TCP_IP6;
-		} else {
-			/* XFW_L4_PROTO_UDP */
-			dst_default = XFW_DEFAULT_DST_UDP_IP6;
+		if (ctx->iph6) {
+			ipv6_populate_dst_key(ctx->iph6, ctx->l4_proto, key);
+			*default_idx = XFW_DEFAULT_DST_TCP_IP6;
+			return true;
 		}
+		return false;
 	}
-
-	return dst_default;
+	if (ctx->uh) {
+		key->port = ctx->uh->dest;
+		if (ctx->iph4) {
+			ipv4_populate_dst_key(ctx->iph4, ctx->l4_proto, key);
+			*default_idx = XFW_DEFAULT_DST_UDP_IP4;
+			return true;
+		}
+		if (ctx->iph6) {
+			ipv6_populate_dst_key(ctx->iph6, ctx->l4_proto, key);
+			*default_idx = XFW_DEFAULT_DST_UDP_IP6;
+			return true;
+		}
+		return false;
+	}
+	return false;
 }
 
 static __always_inline int
-xfw_dst_filter(const XfwGlobalCtx *ctx, const XfwDstKey *dst_key)
+xfw_dst_filter(const XfwGlobalCtx *ctx)
 {
+	XfwDstKey dst_key;
+	uint8_t dst_default;
+	XFW_ASSERT(populate_dst_info(ctx, &dst_key, &dst_default));
+
 	XfwActionRule *rule = bpf_map_lookup_elem(
-		SELECT_SHADOW_MAP(MAP_DST_BASENAME, ctx->cfg->amap_dst),
-				   dst_key);
+		SELECT_SHADOW_MAP(MAP_DST_BASENAME, ctx->cfg->amap_dst), &dst_key);
 
 	if (!rule) {
-		uint8_t dst_default = xfw_dst_default_by_key(dst_key);
 		XfwActionRule *default_rule = &ctx->cfg->rules.defaults[dst_default];
 		if (default_rule->action == XFW_ACTION_BLOCK)
 			return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_DST_BLOCKED, ": %pI6",
-						     &dst_key->addr.in6,
+						     &dst_key.addr.in6,
 						     "(by default action)");
 		if (default_rule->action == XFW_ACTION_ALLOW)
 			return XFW_CTX_CONTINUE;
@@ -70,13 +95,13 @@ xfw_dst_filter(const XfwGlobalCtx *ctx, const XfwDstKey *dst_key)
 			return XFW_CTX_CONTINUE;
 
 		return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_DST_RATE_LIMITED,
-					     ": %pI6", &dst_key->addr.in6,
+					     ": %pI6", &dst_key.addr.in6,
 					     "(by default action)");
 	}
 
 	if (rule->action == XFW_ACTION_BLOCK)
 		return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_DST_BLOCKED, ": %pI6",
-					     &dst_key->addr.in6);
+					     &dst_key.addr.in6);
 
 	if (rule->action == XFW_ACTION_ALLOW)
 		return XFW_CTX_CONTINUE;
@@ -86,7 +111,7 @@ xfw_dst_filter(const XfwGlobalCtx *ctx, const XfwDstKey *dst_key)
 		return XFW_CTX_CONTINUE;
 
 	return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_DST_RATE_LIMITED, ": %pI6",
-				     &dst_key->addr.in6);
+				     &dst_key.addr.in6);
 }
 
 #undef BANNER

--- a/bpf/filter.h
+++ b/bpf/filter.h
@@ -261,26 +261,8 @@ ipv4_populate_lpm_key(__be32 addr, XfwIpv4LpmKey *key)
 }
 
 static __always_inline void
-ipv4_populate_dst_key(const struct iphdr *ip4_hdr, int l4_proto,
-	XfwDstKey *dst_key)
-{
-	dst_key->ipver = XFW_IP_VER_4;
-	dst_key->proto = (uint8_t)l4_proto;
-	xfw_ipv4_to_ipv6_mapped(ip4_hdr->daddr, dst_key->addr.addr32);
-}
-
-static __always_inline void
 ipv6_populate_lpm_key(const struct in6_addr *addr, XfwIpv6LpmKey *key)
 {
 	key->prefixlen = 128;
 	xfw_ipv6_addr_cpy(key->addr, addr);
-}
-
-static __always_inline void
-ipv6_populate_dst_key(const struct ipv6hdr *ip6_hdr, int l4_proto,
-	XfwDstKey *dst_key)
-{
-	dst_key->ipver = XFW_IP_VER_6;
-	dst_key->proto = (uint8_t)l4_proto;
-	dst_key->addr.in6 = ip6_hdr->daddr;
 }

--- a/bpf/tc.c
+++ b/bpf/tc.c
@@ -38,8 +38,7 @@ SHADOW_MAP(MAP_NET_IP6_BASENAME, BPF_MAP_TYPE_LPM_TRIE, XFW_MAX_PROTECTED_NET_RU
  * Parsing function, should not drop packets!
  */
 static __always_inline int
-out_process_l3(XfwGlobalCtx *ctx, XfwDstKey *dst_key, XfwIpLpmKey* prot_net_key,
-	       void **prot_net_map)
+out_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey* prot_net_key, void **prot_net_map)
 {
 	switch (ctx->ipver) {
 	case bpf_ntohs(ETH_P_IP): {
@@ -51,7 +50,6 @@ out_process_l3(XfwGlobalCtx *ctx, XfwDstKey *dst_key, XfwIpLpmKey* prot_net_key,
 		ctx->l4_proto = (u8)proto;
 		xfw_ipv4_to_ipv6_mapped(ctx->iph4->daddr, ctx->ilog_addr.addr32);
 		ipv4_populate_lpm_key(ctx->iph4->daddr, &prot_net_key->addr4);
-		ipv4_populate_dst_key(ctx->iph4, ctx->l4_proto, dst_key);
 		*prot_net_map = SELECT_SHADOW_MAP(MAP_NET_IP4_BASENAME,
 						   ctx->cfg->amap_prot_net);
 		/* It is a regular case, don't need to add any statistic */
@@ -66,7 +64,6 @@ out_process_l3(XfwGlobalCtx *ctx, XfwDstKey *dst_key, XfwIpLpmKey* prot_net_key,
 		ctx->l4_proto = (u8)proto;
 		ctx->ilog_addr.in6 = ctx->iph6->daddr;
 		ipv6_populate_lpm_key(&ctx->iph6->daddr, &prot_net_key->addr6);
-		ipv6_populate_dst_key(ctx->iph6, ctx->l4_proto, dst_key);
 		*prot_net_map = SELECT_SHADOW_MAP(MAP_NET_IP6_BASENAME,
 						   ctx->cfg->amap_prot_net);
 		/* It is a regular case, don't need to add any statistic */
@@ -83,7 +80,7 @@ out_process_l3(XfwGlobalCtx *ctx, XfwDstKey *dst_key, XfwIpLpmKey* prot_net_key,
  * Parsing function, should not drop packets!
  */
 static __always_inline int
-out_process_l4(XfwGlobalCtx *ctx, XfwDstKey *dst_key)
+out_process_l4(XfwGlobalCtx *ctx)
 {
 	switch (ctx->l4_proto) {
 	case XFW_L4_PROTO_TCP: {
@@ -91,7 +88,6 @@ out_process_l4(XfwGlobalCtx *ctx, XfwDstKey *dst_key)
 		if (unlikely(parse_tcphdr(&ctx->hdr_cur, &ctx->th) <= 0))
 			return XFW_MAKE_CTX_PASS(ctx, XFW_TCP_BADHDR_EGRESS);
 
-		dst_key->port = ctx->th->dest;
 		/* It is a regular case, don't need to add any statistic */
 		return XFW_CTX_CONTINUE;
 	}
@@ -99,8 +95,6 @@ out_process_l4(XfwGlobalCtx *ctx, XfwDstKey *dst_key)
 		count_traffic_stat(ctx, XFW_UDP_TOTAL_EGRESS);
 		if (unlikely(parse_udphdr(&ctx->hdr_cur, &ctx->uh) <= 0))
 			return XFW_MAKE_CTX_PASS(ctx, XFW_UDP_BADHDR_EGRESS);
-
-		dst_key->port = ctx->uh->dest;
 
 		egress_dns_filter(ctx);
 
@@ -115,10 +109,10 @@ out_process_l4(XfwGlobalCtx *ctx, XfwDstKey *dst_key)
 }
 
 static __always_inline int
-process_downstream_egress(const XfwGlobalCtx *ctx, const XfwDstKey *dst_key)
+process_downstream_egress(const XfwGlobalCtx *ctx)
 {
 	/* Traffic still heading toward protected services must pass dst policy. */
-	CHAIN(xfw_dst_filter, ctx, dst_key);
+	CHAIN(xfw_dst_filter, ctx);
 
 	return XFW_CTX_CONTINUE;
 }
@@ -128,9 +122,6 @@ xfw_tc_egress_filter(struct XfwGlobalCtx *ctx, bool *is_upstream_egress)
 {
 	void *prot_net_map;
 	XfwIpLpmKey prot_net_key;
-
-	/* Filled by the parsing path that needs it. */
-	XfwDstKey dst_key = {};
 
 	XFW_DBG_INIT();
 
@@ -163,24 +154,19 @@ xfw_tc_egress_filter(struct XfwGlobalCtx *ctx, bool *is_upstream_egress)
 		return XFW_MAKE_CTX_PASS(ctx, XFW_ETH_BADHDR_EGRESS);
 
 	/* Build map lookup keys before policy evaluation. */
-	CHAIN(out_process_l3, ctx, &dst_key, &prot_net_key, &prot_net_map);
-	CHAIN(out_process_l4, ctx, &dst_key);
+	CHAIN(out_process_l3, ctx, &prot_net_key, &prot_net_map);
+	CHAIN(out_process_l4, ctx);
 	/* Parsing is complete; start policy checks. */
 
 	*is_upstream_egress = (bpf_map_lookup_elem(prot_net_map, &prot_net_key) == NULL);
 	if (!*is_upstream_egress) /* Packets going to upstream. */
-		CHAIN(process_downstream_egress, ctx, &dst_key);
+		CHAIN(process_downstream_egress, ctx);
 	
 	/* 
 	 * Still needs to be called when rules are not loaded. TCP AUTH filter is
 	 * atomatically inactive at that time.
 	 */
-	
-	const XfwSockAddr sock_addr = {
-		.addr = dst_key.addr,
-		.port = dst_key.port
-	};
-	tcp_auth_conn_egress_learning(ctx, &sock_addr);
+	tcp_auth_conn_egress_learning(ctx);
 
 	return XFW_CTX_PASS;
 }

--- a/bpf/tcp_auth.h
+++ b/bpf/tcp_auth.h
@@ -195,19 +195,24 @@ tcp_auth_conn_ingress_filter(const XfwGlobalCtx *ctx, const XfwSockAddr *addr,
 }
 
 static __always_inline void
-tcp_auth_conn_egress_learning(const XfwGlobalCtx *ctx, const XfwSockAddr *addr)
+tcp_auth_conn_egress_learning(const XfwGlobalCtx *ctx)
 {
-	if (!ctx->th)
+	struct tcphdr *th = ctx->th;
+	if (!th)
 		return;
 
-	struct tcphdr *th = ctx->th;
+	const XfwSockAddr addr = {
+		.addr = ctx->ilog_addr,
+		.port = th->dest
+	};
+	
 	if (unlikely(th->rst)) {
 		/* An early RST can safely remove a learned tuple. */
-		tcp_auth_conn_delete(addr);
+		tcp_auth_conn_delete(&addr);
 		return;
 	}
 
-	XfwTcpConnState *conn = tcp_auth_conn_lookup(addr);
+	XfwTcpConnState *conn = tcp_auth_conn_lookup(&addr);
 
 	/*
 	 * Trusted connection tracking in tc.c has two modes:
@@ -233,7 +238,7 @@ tcp_auth_conn_egress_learning(const XfwGlobalCtx *ctx, const XfwSockAddr *addr)
 	 */
 	if (!conn) {
 		if (unlikely(!ctx->cfg->rules.tcp_auth.enabled || th->syn))
-			tcp_auth_conn_add(addr);
+			tcp_auth_conn_add(&addr);
 		return;
 	}
 

--- a/bpf/xdp.c
+++ b/bpf/xdp.c
@@ -392,7 +392,7 @@ syn_rlimit(XfwGlobalCtx *ctx)
 }
 
 static __always_inline int
-in_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key, XfwDstKey *dst_key)
+in_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key)
 {
 	switch (ctx->ipver) {
 	case bpf_ntohs(ETH_P_IP): {
@@ -408,7 +408,6 @@ in_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key, XfwDstKey *dst_key)
 		ctx->l4_proto = (u8)proto;
 		xfw_ipv4_to_ipv6_mapped(ctx->iph4->saddr, ctx->ilog_addr.addr32);
 		ipv4_populate_lpm_key(ctx->iph4->saddr, &src_ip_key->addr4);
-		ipv4_populate_dst_key(ctx->iph4, ctx->l4_proto, dst_key);
 		return XFW_CTX_CONTINUE;
 	}
 	case bpf_ntohs(ETH_P_IPV6): {
@@ -423,7 +422,6 @@ in_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key, XfwDstKey *dst_key)
 		ctx->l4_proto = (u8)proto;
 		ctx->ilog_addr.in6 = ctx->iph6->saddr;
 		ipv6_populate_lpm_key(&ctx->iph6->saddr, &src_ip_key->addr6);
-		ipv6_populate_dst_key(ctx->iph6, ctx->l4_proto, dst_key);
 
 		return XFW_CTX_CONTINUE;
 	}
@@ -585,16 +583,16 @@ tcp_flags_filter(XfwGlobalCtx *ctx, const XfwSockAddr *addr)
 }
 
 static __always_inline int
-in_process_l4(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key, XfwDstKey *dst_key)
+in_process_l4(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key)
 {
 	if (!bpf_bitset64_test(ctx->cfg->rules.ip_proto.protocols.data,
-			       dst_key->proto))
+			       ctx->l4_proto))
 	{
 		return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_L4_UNSUPPORTED_INGRESS,
-					     ": %u", dst_key->proto);
+					     ": %u", ctx->l4_proto);
 	}
 
-	switch (dst_key->proto) {
+	switch (ctx->l4_proto) {
 	case XFW_L4_PROTO_TCP: {
 		count_traffic_stat(ctx, XFW_TCP_TOTAL_INGRESS);
 		if (unlikely(parse_tcphdr(&ctx->hdr_cur, &ctx->th) <= 0))
@@ -602,7 +600,6 @@ in_process_l4(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key, XfwDstKey *dst_key)
 
 		CHAIN(tcp_anomaly_filter, ctx);
 
-		dst_key->port = ctx->th->dest;
 		CHAIN(src_filter, ctx, ctx->th->source, src_ip_key);
 		
 		const XfwSockAddr addr = {
@@ -619,24 +616,23 @@ in_process_l4(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key, XfwDstKey *dst_key)
 		if (ctx->uh->source == 0 || ctx->uh->dest == 0)
 			return XFW_MAKE_CTX_DROP(ctx, XFW_UDP_ANOM_ZERO_PORT);
 
-		dst_key->port = ctx->uh->dest;
-
 		CHAIN(ingress_dns_filter, ctx);
 		return src_filter(ctx, ctx->uh->source, src_ip_key);
 	};
 	case XFW_L4_PROTO_ICMP:
 	case XFW_L4_PROTO_ICMPV6: {
-		XfwICMPCommon *ih;
-		XfwIcmpKey key;
 		count_traffic_stat(ctx, XFW_ICMP_TOTAL_INGRESS);
 
+		XfwICMPCommon *ih;
 		if (unlikely(parse_icmphdr_common(&ctx->hdr_cur, &ih) < 0))
 			return XFW_MAKE_CTX_DROP(ctx, XFW_ICMP_BADHDR_INGRESS);
 
 		XFW_CTX_DBG("ICMP header parsed, type=%u", ih->type);
 
-		key.proto = dst_key->proto;
-		key.type = ih->type;
+		const XfwIcmpKey key = {
+			.proto = ctx->l4_proto,
+			.type = ih->type
+		};
 		CHAIN(icmp_filter, ctx, &key);
 		CHAIN(src_filter_ip, ctx, src_ip_key);
 		/* ICMP has no destination port, so dst rules cannot refine this path. */
@@ -662,11 +658,6 @@ do {									\
 static __always_inline int
 xfw_xdp_filter(struct XfwGlobalCtx *ctx)
 {
-	int r;
-	/* Helper structure for src filter, filled on L3, used on L4. */
-	XfwIpLpmKey src_ip_key = {};
-	XfwDstKey dst_key = {};
-
 	count_traffic_stat(ctx, XFW_TOTAL_DOWNSTREAM_INGRESS);
 
 	XFW_DBG_INIT();
@@ -680,9 +671,12 @@ xfw_xdp_filter(struct XfwGlobalCtx *ctx)
 	if (unlikely(ctx->ipver < 0))
 		return XFW_MAKE_CTX_DROP(ctx, XFW_ETH_BADHDR_INGRESS);
 
-	CHAIN_PASS_ALL(in_process_l3, ctx, &src_ip_key, &dst_key);
-	CHAIN_PASS_ALL(in_process_l4, ctx, &src_ip_key, &dst_key);
-	CHAIN_PASS_ALL(xfw_dst_filter, ctx, &dst_key);
+	int r;
+	/* Helper structure for src filter, filled on L3, used on L4. */
+	XfwIpLpmKey src_ip_key = {};
+	CHAIN_PASS_ALL(in_process_l3, ctx, &src_ip_key);
+	CHAIN_PASS_ALL(in_process_l4, ctx, &src_ip_key);
+	CHAIN_PASS_ALL(xfw_dst_filter, ctx);
 
 pass:
 	count_traffic_stat(ctx, XFW_PASSED_DOWNSTREAM_INGRESS);


### PR DESCRIPTION
Delay initialization until first use. Populate XfwDstKey only in the destination filter and construct XfwSockAddr only in the TCP auth path. Besides avoiding unnecessary work, this shortens variable live ranges and simplifies control flow, giving the compiler and BPF verifier more optimization opportunities.