### PR TITLE
fix skip mark for test with ratelimit

### DIFF
--- a/t/func/tests/test_icmp.py
+++ b/t/func/tests/test_icmp.py
@@ -95,7 +95,8 @@ async def test_block_by_type(
     assert await icmp_raw_client.pong() is False
 
 
-@pytest.mark.fail_in_gate_mode("ISSUE: 456, 39")
+@pytest.mark.fail_in_gate_mode("ISSUE: 456")
+@pytest.mark.skip(reason="ISSUE: 39 (xFW)")
 async def test_default_ratelimit(
     xfw: XFW,
     ip_version: str,


### PR DESCRIPTION
Test failed [here](https://github.com/tempesta-tech/xFW/pull/41), but supposed to be skipped