### PR TITLE
bpf: reduce XDP stack usage by moving packet context to per-cpu map

### DIFF
--- a/bpf/ctx.h
+++ b/bpf/ctx.h
@@ -43,10 +43,18 @@ typedef struct XfwHdrCursor {
  * Global processing context.
  * This is required as eBPF has a limit to 5 function arguments.
  *
- * @ipver	- ETH_P_IP or ETH_P_IPV6
- * @ctx		- xdp_md or __sk_buff, depending on hook
- * @ts_jiff	- current jiffies timestamp shared by all filters
- * @l4_proto	- XFW_L4_PROTO_UDP or XFW_L4_PROTO_TCP if != 0
+ * The context is intentionally kept on the stack and passed through the call
+ * chain to avoid unnecessary accesses to BPF maps. In some cases, verifier
+ * limitations (for example, stack depth restrictions, tail calls, or program
+ * splitting) may require moving part of the processing state (scalar values)
+ * into a shared BPF map. This approach should be considered as a possible
+ * optimization and compatibility strategy if verifier constraints become a
+ * limiting factor (see doc/ebpf_verifier.md for more detailes).
+ *
+ * @ipver      - ETH_P_IP or ETH_P_IPV6
+ * @ctx        - xdp_md or __sk_buff, depending on hook
+ * @ts_jiff    - current jiffies timestamp shared by all filters
+ * @l4_proto   - XFW_L4_PROTO_UDP or XFW_L4_PROTO_TCP if != 0
  */
 typedef struct XfwGlobalCtx {
 	XfwFilterCfg	*cfg;

--- a/doc/ebpf_verifier.md
+++ b/doc/ebpf_verifier.md
@@ -76,3 +76,87 @@ generated BPF code.
 Debug and Release builds may produce different stack layouts. The
 verifier analyzes the generated BPF instructions, not the C source, so a
 program that verifies in one build configuration may fail in another.
+
+## Moving scalar context to a BPF map
+
+In some cases the eBPF verifier may become a limiting factor due to stack
+size restrictions, function complexity, or program decomposition requirements.
+One possible optimization strategy is to move a subset of the packet processing
+context from the stack into a per-CPU BPF map. Only scalar values should be
+moved this way. Pointers to packet data, packet headers, cursor structures, or
+other verifier-tracked references must remain on the stack because they cannot
+be safely transferred through BPF maps.
+
+For example, the following subset of `XfwGlobalCtx` can be stored in a map:
+
+```c
+typedef struct XfwPktCtx {
+	uint32_t	pkt_sz;
+	int		ipver;
+	uint64_t	ts_jiff;
+	uint8_t		l4_proto;
+	XfwIp		ilog_addr;
+} XfwPktCtx;
+```
+
+The corresponding map:
+
+```c
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__type(key, __u32);
+	__type(value, XfwPktCtx);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, 1);
+} xfw_pkt_ctx SEC(".maps");
+```
+
+The global context then stores a pointer to the per-CPU map value instead of
+keeping all scalar fields on the stack:
+
+```c
+typedef struct XfwGlobalCtx {
+	...
+	XfwPktCtx *pkt_ctx;
+	...
+} XfwGlobalCtx;
+```
+
+The pointer is initialized during context setup:
+
+```c
+static __always_inline int
+xfw_ctx_init(XfwGlobalCtx *ctx, XfwMd *pkt_ctx)
+{
+	const unsigned zero = 0;
+
+	memset(ctx, 0, sizeof(*ctx));
+
+	ctx->cfg = bpf_map_lookup_elem(&MAP_CFG_REF, &zero);
+	ctx->g_stats = bpf_map_lookup_elem(&MAP_GLBL_STAT_REF, &zero);
+	ctx->pkt_ctx = bpf_map_lookup_elem(&xfw_pkt_ctx, &zero);
+
+	if (unlikely(!(ctx->cfg && ctx->g_stats && ctx->pkt_ctx)))
+		return -1;
+
+	memset(ctx->pkt_ctx, 0, sizeof(*ctx->pkt_ctx));
+
+	INIT_CURSOR_FROM_BPF_CONTEXT(pkt_ctx, &ctx->hdr_cur);
+
+	ctx->pkt_sz = ctx->hdr_cur.end - ctx->hdr_cur.pos;
+	ctx->pkt_ctx->pkt_sz = ctx->pkt_sz;
+
+	ctx->ctx = pkt_ctx;
+
+	ctx->ts_jiff = bpf_jiffies64();
+	ctx->pkt_ctx->ts_jiff = ctx->ts_jiff;
+
+	return 0;
+}
+```
+
+This approach allows reducing stack pressure while preserving access to
+frequently used scalar packet metadata. At the moment, keeping data on the
+stack is generally preferred because stack accesses are cheaper than map
+accesses. Therefore, this technique should be considered only when verifier
+limitations become a practical issue.


### PR DESCRIPTION
Move packet-specific fields from XfwGlobalCtx to a separate XfwPacketCtx stored in a percpu array map. This reduces the size of XfwGlobalCtx and lowers stack consumption across nested BPF subprogram calls. (The previous layout caused excessive stack usage: "combined stack size of 3 calls is 544").
By keeping the large packet context outside the stack frame, verifier can successfully validate deeper call chains with multiple subprograms. Also make some codestyle fixes (the length of the code string should not be greater than 80 symbols).