### PR TITLE
reduce XfwGlobalCtx stack usage by packing protocol fields

### DIFF
--- a/bpf/ctx.h
+++ b/bpf/ctx.h
@@ -61,7 +61,8 @@ typedef struct XfwGlobalCtx {
 	XfwPerCpuStats	*g_stats;
 	XfwHdrCursor	hdr_cur;
 	uint32_t	pkt_sz;
-	int		ipver;
+	uint16_t	ipver;
+	uint8_t		l4_proto;
 	XfwMd		*ctx;
 	struct ethhdr	*eth;
 	struct iphdr	*iph4;
@@ -69,7 +70,6 @@ typedef struct XfwGlobalCtx {
 	struct tcphdr	*th;
 	struct udphdr	*uh;
 	uint64_t	ts_jiff;
-	uint8_t		l4_proto;
 	XfwIp		ilog_addr;
 } XfwGlobalCtx;
 


### PR DESCRIPTION
Apply one of the stack size reduction ideas from ak-544-tcp-options: place small protocol-related fields next to each other to allow the compiler to pack them more efficiently.

Change ipver from int to uint16_t and move l4_proto next to it. This reduces XDP stack usage by 8 bytes without moving data out of the stack or adding additional map accesses.