### PR TITLE
reject IPv4-embedded IPv6 prefixes.

### DIFF
--- a/bpf/parsing_helpers.h
+++ b/bpf/parsing_helpers.h
@@ -200,6 +200,14 @@ parse_ip6hdr(XfwHdrCursor *cur, struct ipv6hdr **ip6hdr)
 	cur->pos = ip6h + 1;
 	*ip6hdr = ip6h;
 
+	/*
+	 * RFC 6890 marks these prefixes as invalid IPv6 packet source and
+	 * destination addresses (Source=False, Destination=False).
+	 */
+	if (xfw_is_ipv4_embedded_ipv6(ip6h->saddr.in6_u.u6_addr32)
+	    || xfw_is_ipv4_embedded_ipv6(ip6h->daddr.in6_u.u6_addr32))
+		return -EINVAL;
+
 	XFW_CTX_DBG("IPv6 packet: %pI6 -> %pI6", &ip6h->saddr, &ip6h->daddr);
 
 	return skip_ip6hdrext(cur, ip6h->nexthdr);

--- a/bpf/xdp.c
+++ b/bpf/xdp.c
@@ -91,25 +91,6 @@ create_metadata(XfwGlobalCtx *ctx, struct xdp_md *xdp)
 	return XFW_CTX_CONTINUE;
 }
 
-/* Rewrite IPv4-mapped IPv6 LPM keys so IPv4 source rules can handle them. */
-static __always_inline int
-try_convert_ipv6_to_ipv4(XfwIpLpmKey *key)
-{
-	if (key->addr6.addr[0] == 0 && key->addr6.addr[1] == 0
-	    && (key->addr6.addr[2] == 0
-		|| key->addr6.addr[2] == bpf_htonl(0xffff)))
-	{
-		__be32 ip4 = key->addr6.addr[3];
-		key->addr4.prefixlen = key->addr6.prefixlen - 96;
-		key->addr4.addr = ip4;
-
-		XFW_CTX_DBG("IPv4-mapped source key matched the IPv4 rule tree");
-
-		return 0;
-	}
-	return -1;
-}
-
 static __always_inline uint8_t
 icmp_default_by_proto(uint8_t l4_proto)
 {
@@ -241,17 +222,10 @@ src_filter_port(const XfwGlobalCtx *ctx, XfwPort port)
 }
 
 static __always_inline void
-populate_src_info(const XfwGlobalCtx *ctx, void **src_ip_map,
-		  XfwIpLpmKey *ip_lpm, uint8_t *src_default)
+populate_src_info(const XfwGlobalCtx *ctx, const XfwIpLpmKey *ip_lpm,
+		  void **src_ip_map, uint8_t *src_default)
 {
-	/*
-	 * Handle special case of IPv6 address with embedded IPv4.
-	 * This was firstly introduced for geoip matching.
-	 * src filter treats those ipv6 addresses as ipv4.
-	 * So for consistency we use ipv4 defaults in this case.
-	 */
-	if (ctx->ipver == bpf_htons(ETH_P_IPV6)
-	    && try_convert_ipv6_to_ipv4(ip_lpm) < 0)
+	if (ctx->ipver == bpf_htons(ETH_P_IPV6))
 	{
 		if (ctx->l4_proto == XFW_L4_PROTO_UDP) {
 			*src_default = XFW_DEFAULT_SRC_IP_UDP_IP6;
@@ -287,11 +261,11 @@ populate_src_info(const XfwGlobalCtx *ctx, void **src_ip_map,
  * information) in addition to the IP address.
  */
 static __always_inline int
-src_filter_ip(const XfwGlobalCtx *ctx, XfwIpLpmKey *ip_lpm)
+src_filter_ip(const XfwGlobalCtx *ctx, const XfwIpLpmKey *ip_lpm)
 {
 	uint8_t src_default;
 	void *src_ip_map;
-	populate_src_info(ctx, &src_ip_map, ip_lpm, &src_default);
+	populate_src_info(ctx, ip_lpm, &src_ip_map, &src_default);
 
 	XfwSrcRule *rule = bpf_map_lookup_elem(src_ip_map, ip_lpm);
 

--- a/bpf_uapi/ip_helpers.h
+++ b/bpf_uapi/ip_helpers.h
@@ -27,11 +27,27 @@ xfw_ipv4_to_ipv6_mapped(__be32 ipv4, __be32 addr[4])
 	addr[3] = ipv4;
 }
 
-static __always_inline int
-xfw_is_ipv6_mapped_to_ipv4(const __be32 addr[4])
+/*
+ * Return true if @addr is an IPv4-embedded IPv6 address.
+ *
+ * Matches both deprecated IPv4-compatible (::a.b.c.d) and IPv4-mapped
+ * (::ffff:a.b.c.d) IPv6 address formats.
+ *
+ * RFC 6890 marks these prefixes as invalid IPv6 packet source and
+ * destination addresses (Source=False, Destination=False).
+ */
+static __always_inline bool
+xfw_is_ipv4_embedded_ipv6(const __be32 addr[4])
 {
-	return (addr[0] == 0 && addr[1] == 0 &&
-	       (addr[2] == 0 || addr[2] == HTONL(0xffff)));
+	if (addr[0] || addr[1])
+		return false;
+	
+	if (addr[2] == 0) {
+		/* Exclude :: and ::1. */
+		return addr[3] != 0 && addr[3] != HTONL(1);
+	}
+
+	return addr[2] == HTONL(0xffff);
 }
 
 static __always_inline void

--- a/manager/xfw/configuration.hh
+++ b/manager/xfw/configuration.hh
@@ -101,10 +101,10 @@ public:
 	{
 		//we never use prefix and port in the same time
 		union {
-			uint16_t		prefixlen_ = 0;	//for src
+			uint16_t	prefixlen_ = 0;	//for src
 			NetPort		port_;		//for dst
 		};
-		__be32		addr_ = 0;
+		__be32			addr_ = 0;
 
 		bool operator<(const Net4Key &o) const
 		{
@@ -118,10 +118,10 @@ public:
 	{
 		//we never use prefix and port in the same time
 		union {
-			uint16_t		prefixlen_ = 0;	//for src
+			uint16_t	prefixlen_ = 0;	//for src
 			NetPort		port_;		//for dst
 		};
-		__be32		addr_[4] {0, 0, 0, 0};
+		__be32			addr_[4] {0, 0, 0, 0};
 
 		bool operator<(const Net6Key &o) const
 		{

--- a/manager/xfw/geoip.cc
+++ b/manager/xfw/geoip.cc
@@ -345,6 +345,17 @@ import_ipv4_tree(MMDB_s &mmdb, Ip4PrefixBuckets &prefixes)
 		add_country_prefix(prefixes, result.entry, Ip4Addr{}, 0);
 }
 
+static bool
+xfw_is_ipv4_embedded_ipv6(const Ip6Addr &addr) noexcept
+{
+	if (!std::ranges::all_of(addr.begin(), addr.begin() + 10,
+				 [](std::uint8_t b) { return b == 0; }))
+		return false;
+
+	return (addr[10] == 0 && addr[11] == 0)
+		|| (addr[10] == 0xff && addr[11] == 0xff);
+}
+
 void
 import_ipv6_tree(MMDB_s &mmdb, Ip6PrefixBuckets &prefixes)
 {
@@ -359,6 +370,10 @@ import_ipv6_tree(MMDB_s &mmdb, Ip6PrefixBuckets &prefixes)
 	auto add_data = [&prefixes](MMDB_entry_s entry, const Ip6Addr &addr,
 				    unsigned prefixlen)
 	{
+		if (xfw_is_ipv4_embedded_ipv6(addr))
+			throw Except("Unexpected IPv4-embedded prefix in IPv6 "
+				     "search tree");
+
 		add_country_prefix(prefixes, entry, addr, prefixlen);
 	};
 

--- a/manager/xfw_config_updater.cc
+++ b/manager/xfw_config_updater.cc
@@ -691,6 +691,9 @@ XfwConfigUpdater::add_matchers_to<ProtoNetRule, XfwConfig::NetIp>(
 	if (proto.net6s()) {
 		for (size_t j = 0; j < proto.net6s()->size(); ++j) {
 			auto key = get_net6key(proto.net6s()->Get(j), to.flags_);
+			if (xfw_is_ipv4_embedded_ipv6(key.addr_))
+				throw Except("Unexpected IPv4-compatible prefix "
+					     "in IPv6 address");
 			auto [it, inserted] = to.net6s_.insert(key);
 			if (!inserted) {
 				throw UpdateError("Error on add: Net6 "

--- a/t/func/tests/test_dst_rule_add.py
+++ b/t/func/tests/test_dst_rule_add.py
@@ -201,29 +201,25 @@ async def test_dst_add_only_one_protocol_subtype(
         ), f"Server {new_server.ip_testing}:{new_server.port} is not allowed"
 
 
-@pytest.mark.skip("ISSUE: 336 (escudo)")
-async def test_dst_add_block_by_ip_mapped(
+async def test_dst_reject_to_add_ip_mapped(
     xfw: XFW,
     udp_ip4_client: RegularKernelSocketNetworkStateful,
     udp_ip4_mapped_ip6_server: RegularKernelSocketNetworkStateful,
 ):
-    new_ip = udp_ip4_mapped_ip6_server.generate_new_address()
-
     await xfw.rules_set(f"""
         xfw {{
             defaults {{ dst: allow; }}
             dst=extended_group ip6.udp : block {{
-                {udp_ip4_mapped_ip6_server.ip_format(new_ip)}:{udp_ip4_mapped_ip6_server.port}
+                [fd00:20::2]:10000
             }}
         }}
         """)
-    await xfw.rules_patch(f"""
-        xfw {{
-            dst=extended_group/add ip6.udp {{
-                {udp_ip4_mapped_ip6_server.ip_testing}:{udp_ip4_mapped_ip6_server.port}
+
+    with pytest.raises(ValueError):
+        await xfw.rules_patch(f"""
+            xfw {{
+                dst=extended_group/add ip6.udp {{
+                    {udp_ip4_mapped_ip6_server.ip_testing}:{udp_ip4_mapped_ip6_server.port}
+                }}
             }}
-        }}
-        """)
-    assert (
-        await check_connection(udp_ip4_client, udp_ip4_mapped_ip6_server) is False
-    ), f"Server ({udp_ip4_mapped_ip6_server.ip_testing}:{udp_ip4_mapped_ip6_server.port}) is not blocked"
+            """)

--- a/t/func/tests/test_dst_rule_allow.py
+++ b/t/func/tests/test_dst_rule_allow.py
@@ -136,23 +136,3 @@ async def test_dst_allow_only_one_protocol_subtype(
         assert (
             await check_connection(new_client, new_server) is False
         ), f"Server {new_server.ip_testing}:{new_server.port} is not blocked"
-
-
-@pytest.mark.skip("ISSUE: 336 (escudo)")
-async def test_dst_allowed_ip_mapped(
-    xfw: XFW,
-    udp_ip4_client: RegularKernelSocketNetworkStateful,
-    udp_ip4_mapped_ip6_server: RegularKernelSocketNetworkStateful,
-):
-    await xfw.rules_set(f"""
-        xfw {{
-            defaults {{ dst: block; }}
-            dst ip6.udp : allow {{
-                {udp_ip4_mapped_ip6_server.ip_testing}:{udp_ip4_mapped_ip6_server.port}
-            }}
-        }}
-        """)
-
-    assert (
-        await check_connection(udp_ip4_client, udp_ip4_mapped_ip6_server) is True
-    ), f"Server {udp_ip4_mapped_ip6_server.ip_testing}:{udp_ip4_mapped_ip6_server.port} is not available"

--- a/t/func/tests/test_dst_rule_block.py
+++ b/t/func/tests/test_dst_rule_block.py
@@ -138,23 +138,3 @@ async def test_dst_block_only_one_protocol_subtype(
         assert (
             await check_connection(new_client, new_server) is True
         ), f"Server {new_server.ip_testing}:{new_server.port} is not allowed"
-
-
-@pytest.mark.skip("ISSUE: 336 (escudo)")
-async def test_dst_block_by_ip_mapped(
-    xfw: XFW,
-    udp_ip4_client: RegularKernelSocketNetworkStateful,
-    udp_ip4_mapped_ip6_server: RegularKernelSocketNetworkStateful,
-):
-    await xfw.rules_set(f"""
-        xfw {{
-            defaults {{ dst: allow; }}
-            dst ip6.udp : block {{
-                {udp_ip4_mapped_ip6_server.ip_testing}:{udp_ip4_mapped_ip6_server.port}
-            }}
-        }}
-        """)
-
-    assert (
-        await check_connection(udp_ip4_client, udp_ip4_mapped_ip6_server) is False
-    ), f"IP {udp_ip4_mapped_ip6_server.ip_testing}:{udp_ip4_mapped_ip6_server.port} is not blocked"

--- a/t/func/tests/test_dst_rule_del.py
+++ b/t/func/tests/test_dst_rule_del.py
@@ -210,28 +210,3 @@ async def test_dst_del_only_one_protocol_subtype(
         assert (
             await check_connection(new_client, new_server) is False
         ), f"Server {new_server.ip_testing}:{new_server.port} is not blocked"
-
-
-async def test_dst_del_block_by_ip_mapped(
-    xfw: XFW,
-    udp_ip4_client: RegularKernelSocketNetworkStateful,
-    udp_ip4_mapped_ip6_server: RegularKernelSocketNetworkStateful,
-):
-    await xfw.rules_set(f"""
-        xfw {{
-            defaults {{ dst: allow; }}
-            dst=extended_group ip6.udp : block {{
-                {udp_ip4_mapped_ip6_server.ip_testing}:{udp_ip4_mapped_ip6_server.port}
-            }}
-        }}
-        """)
-    await xfw.rules_patch(f"""
-        xfw {{
-            dst=extended_group/del ip6.udp {{
-                {udp_ip4_mapped_ip6_server.ip_testing}:{udp_ip4_mapped_ip6_server.port}
-            }}
-        }}
-        """)
-    assert await check_connection(
-        udp_ip4_client, udp_ip4_mapped_ip6_server
-    ), f"IP {udp_ip4_mapped_ip6_server.ip_testing}:{udp_ip4_mapped_ip6_server.port} is blocked"

--- a/t/func/tests/test_dst_rule_replace.py
+++ b/t/func/tests/test_dst_rule_replace.py
@@ -162,27 +162,30 @@ async def test_dst_replace_only_one_protocol_subtype(
         ), f"Server {new_server.ip_testing}:{new_server.port} is not blocked"
 
 
-@pytest.mark.skip("ISSUE: 336 (escudo)")
-async def test_dst_replace_block_by_ip_to_allow_by_ip_mapped(
+async def test_dst_reject_on_replace_block_by_ip_by_allow_by_ip_mapped(
     xfw: XFW,
     udp_ip4_client: RegularKernelSocketNetworkStateful,
     udp_ip4_mapped_ip6_server: RegularKernelSocketNetworkStateful,
 ):
+    """
+    The mapped ip4 address should be rejected by the app
+    and error has to appear on rules applying
+    """
+
     await xfw.rules_set(f"""
         xfw {{
             defaults {{ dst: block; }}
             dst=extended_group ip6.udp : block {{
-                {udp_ip4_mapped_ip6_server.ip_testing}:{udp_ip4_mapped_ip6_server.port}
+                [fd00:20::2]:10000
             }}
         }}
         """)
-    await xfw.rules_patch(f"""
-        xfw {{
-            dst=extended_group/replace ip6.udp : allow {{
-                {udp_ip4_mapped_ip6_server.ip_testing}:{udp_ip4_mapped_ip6_server.port}
+
+    with pytest.raises(ValueError):
+        await xfw.rules_patch(f"""
+            xfw {{
+                dst=extended_group/replace ip6.udp : allow {{
+                    {udp_ip4_mapped_ip6_server.ip_testing}:{udp_ip4_mapped_ip6_server.port}
+                }}
             }}
-        }}
-        """)
-    assert await check_connection(
-        udp_ip4_client, udp_ip4_mapped_ip6_server
-    ), f"Server ({udp_ip4_mapped_ip6_server.ip_testing}:{udp_ip4_mapped_ip6_server.port}) is not allowed"
+            """)

--- a/t/func/tests/test_xfw.py
+++ b/t/func/tests/test_xfw.py
@@ -465,7 +465,6 @@ async def test_restart(xfw: XFW):
     await xfw.rules_push_config(" xfw { defaults { dst: allow; } } ")
 
 
-@pytest.mark.skip("ISSUE: 336 (escudo)")
 @pytest.mark.parametrize(
     "rules",
     [


### PR DESCRIPTION
Reject IPv4-compatible and IPv4-mapped IPv6 prefixes when parsing IPv6 packet filtering rules.

IPv4-compatible addresses have been deprecated since RFC 4291. RFC 6890 further specifies that IPv4-mapped addresses are not valid IPv6 packet source or destination addresses (Source=False, Destination=False). Therefore, neither format is expected to appear in legitimate IPv6 packet traffic.

Rejecting these prefixes also simplifies GeoIP lookups. MaxMind DBs do not contain IPv4-compatible or IPv4-mapped IPv6 prefixes: IPv4 networks are stored exclusively in the IPv4 search tree. Users should use native IPv4 prefixes and IPv4 GeoIP databases instead of IPv4-embedded IPv6 forms.

Closes 336(escudo), 331(escudo)