### PR TITLE
put banners into the stack.

### DIFF
--- a/bpf/filter.h
+++ b/bpf/filter.h
@@ -13,9 +13,9 @@
 #include "../bpf_uapi/ip_helpers.h"
 
 /* Print debug messages of the context of a subsustem using the routines. */
-#ifndef BANNER
+#pragma push_macro("BANNER")
+#undef BANNER
 #define BANNER "filter"
-#endif
 #include "../bpf_uapi/proto_keys.h"
 
 #include "log.h"
@@ -266,3 +266,6 @@ ipv6_populate_lpm_key(const struct in6_addr *addr, XfwIpv6LpmKey *key)
 	key->prefixlen = 128;
 	xfw_ipv6_addr_cpy(key->addr, addr);
 }
+
+#undef BANNER
+#pragma pop_macro("BANNER")

--- a/bpf/log.h
+++ b/bpf/log.h
@@ -13,9 +13,9 @@
  * the debug messages.
  * The header should be included first to not to confuse the variable definition.
  */
-#ifndef BANNER
+#pragma push_macro("BANNER")
+#undef BANNER
 #define BANNER "main"
-#endif
 
 #ifdef XFW_DEBUG
 
@@ -53,3 +53,6 @@ do {									\
  */
 #define XFW_ASSERT(v)							\
 	VERIFY_TRUE_OR_RETURN((v), XFW_MAKE_CTX_PASS(ctx, XFW_ASSERT_FAILED))
+
+#undef BANNER
+#pragma pop_macro("BANNER")


### PR DESCRIPTION
Previously, the log message was:

[dns] pkt d34b0d71, [in] Source address for the problematic packet is not yet known

Now it will be:

[filter] pkt d34b0d71, [in] Source address for the problematic packet is not yet known