### PR TITLE
xfw: add XXH64-based SYN tuple hashing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ MAKEFLAGS += --jobs=$(JOBS)
 export CXX CC CXXFLAGS CFLAGS LDFLAGS INCLUDES MAKEFLAGS BUILD_DIR Q
 export BINDIR SBINDIR LIBDIR INCLUDEDIR BUILD_LIBDIR BUILD_BINDIR BUILD_SBINDIR BUILD_INCLUDE
 
-.PHONY: all help build install clean test clang-format print-all
+.PHONY: all help build install clean test benchmark clang-format print-all
 
 .SUFFIXES:
 
@@ -64,11 +64,12 @@ help:
 	@echo " * 'build'	- build all Tempesta xFW modules"
 	@echo " * 'install'	- Install binaries and documents to system locations"
 	@echo " * 'test'	- Execute unit tests"
+	@echo " * 'benchmark'	- Execute benchmarks"
 	@echo " * 'clean'	- Clean artifacts"
 	@echo " * 'help'	- Show this help message"
 	@echo " * 'print-all'	- Print out all makefile variables computed in runtime"
 
-SUBDIRS := lib cli manager bpf logger t
+SUBDIRS := lib cli manager bpf logger t benchmarks
 
 .PHONY: $(SUBDIRS) prepare_dirs
 
@@ -99,6 +100,9 @@ logger: | prepare_dirs
 t: | prepare_dirs
 	@$(MAKE) -C $@ build
 
+benchmarks: | prepare_dirs
+	@$(MAKE) -C $@ build
+
 clang-format:
  	#find . -name '*.cc' -o -name '*.c' -o -name '*.h' -o -name '*.hh' | xargs clang-format -i
 
@@ -120,6 +124,9 @@ install:
 
 test:
 	@$(foreach dir,$(SUBDIRS),$(MAKE) -C $(dir) test || exit 1;)
+
+benchmark:
+	$(MAKE) -C benchmarks benchmark
 
 FORCE:
 

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ install:
 	done
 
 test:
-	@$(foreach dir,$(SUBDIRS),$(MAKE) -C $(dir) test || exit 1)
+	@$(foreach dir,$(SUBDIRS),$(MAKE) -C $(dir) test || exit 1;)
 
 FORCE:
 

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ help:
 	@echo " * 'help'	- Show this help message"
 	@echo " * 'print-all'	- Print out all makefile variables computed in runtime"
 
-SUBDIRS := lib cli manager bpf logger
+SUBDIRS := lib cli manager bpf logger t
 
 .PHONY: $(SUBDIRS) prepare_dirs
 
@@ -94,6 +94,9 @@ bpf: $(BUILD_INCLUDE)/vmlinux.h | prepare_dirs
 
 # NOTE: The logger and all its dependencies are built with g++
 logger: | prepare_dirs
+	@$(MAKE) -C $@ build
+
+t: | prepare_dirs
 	@$(MAKE) -C $@ build
 
 clang-format:

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,0 +1,41 @@
+#
+# Tempesta xFW benchmarks
+#
+# SPDX-FileCopyrightText: © 2026 Tempesta Technologies, Inc.
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+OBJ_DIR := BUILD
+TARGET  := $(OBJ_DIR)/benchmark
+
+SOURCES := $(wildcard *.cc)
+OBJECTS := $(patsubst %.cc,$(OBJ_DIR)/%.o,$(SOURCES))
+DEPS    := $(OBJECTS:.o=.d)
+
+CPPFLAGS += -I../..
+
+.PHONY: build benchmark clean install
+
+build: $(TARGET)
+
+$(TARGET): $(OBJECTS)
+	$(CXX) -o $@ $^ $(LDFLAGS) $(LDLIBS) -lbenchmark
+
+$(OBJ_DIR)/%.o: %.cc
+	@mkdir -p $(dir $@)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -MMD -MP -c $< -o $@
+
+clean: FORCE
+	rm -rf $(OBJ_DIR)
+
+install:
+
+-include $(DEPS)
+
+benchmark:
+	@echo $(BUILD_DIR)
+	$(TARGET)
+
+test:
+
+FORCE:

--- a/benchmarks/benchmark.cc
+++ b/benchmarks/benchmark.cc
@@ -1,0 +1,147 @@
+#include <benchmark/benchmark.h>
+#include <random>
+#include <cstdint>
+#include <climits>
+
+using namespace std;
+
+extern "C" {
+#include "../bpf/syn_hash.h"
+#include "jhash.h"
+#include <linux/limits.h>
+}
+
+#define OBJ_COUNT_MAX 100000
+
+static XfwIpv4SynTuple syn_xxhash_ip4[OBJ_COUNT_MAX];
+static XfwIpv4SynTuple syn_jhash_ip4[OBJ_COUNT_MAX];
+static XfwIpv6SynTuple syn_xxhash_ip6[OBJ_COUNT_MAX];
+static XfwIpv6SynTuple syn_jhash_ip6[OBJ_COUNT_MAX];
+
+static void
+BM_syn_xxhash_ip4(benchmark::State& state)
+{
+	unsigned int idx = 0;
+	random_device rd;
+	mt19937 gen(rd());
+	uniform_int_distribution<uint32_t> distrib_ip(1, UINT_MAX);
+	uniform_int_distribution<uint32_t> distrib_port(1, 65535);
+	uniform_int_distribution<uint32_t> distrib(1, UINT_MAX);
+	uint64_t val = distrib(gen);
+
+	static_assert(sizeof(XfwIpv4SynTuple) == 16);
+
+	for (unsigned int i = 0; i < OBJ_COUNT_MAX; i++) {
+		syn_xxhash_ip4[i].src_ip = distrib_ip(gen);
+		syn_xxhash_ip4[i].dst_ip = distrib_ip(gen);
+		syn_xxhash_ip4[i].seq = distrib(gen);
+		syn_xxhash_ip4[i].sport = distrib_port(gen);
+		syn_xxhash_ip4[i].dport = distrib_port(gen);
+	}
+
+	for (auto _ : state) {
+		idx++;
+		idx %= OBJ_COUNT_MAX;
+		__u64 hash = syn_xxh64_ipv4(&syn_xxhash_ip4[idx], val);
+		benchmark::DoNotOptimize(hash);
+	}
+}
+BENCHMARK(BM_syn_xxhash_ip4);
+
+static void
+BM_syn_jhash_ip4(benchmark::State& state)
+{
+	unsigned int idx = 0;
+	random_device rd;
+	mt19937 gen(rd());
+	uniform_int_distribution<uint32_t> distrib_ip(1, UINT_MAX);
+	uniform_int_distribution<uint32_t> distrib_port(1, 65535);
+	uniform_int_distribution<uint32_t> distrib(1, UINT_MAX);
+	uint64_t val = distrib(gen);
+
+	static_assert(sizeof(XfwIpv4SynTuple) == 16);
+
+	for (unsigned int i = 0; i < OBJ_COUNT_MAX; i++) {
+		syn_jhash_ip4[i].src_ip = distrib_ip(gen);
+		syn_jhash_ip4[i].dst_ip = distrib_ip(gen);
+		syn_jhash_ip4[i].seq = distrib(gen);
+		syn_jhash_ip4[i].sport = distrib_port(gen);
+		syn_jhash_ip4[i].dport = distrib_port(gen);
+	}
+
+	for (auto _ : state) {
+		idx++;
+		idx %= OBJ_COUNT_MAX;
+		__u64 hash = jhash(&syn_jhash_ip4[idx],
+				   sizeof(XfwIpv4SynTuple), val);
+		benchmark::DoNotOptimize(hash);
+	}
+}
+BENCHMARK(BM_syn_jhash_ip4);
+
+static void
+BM_syn_xxhash_ip6(benchmark::State& state)
+{
+	unsigned int idx = 0;
+	random_device rd;
+	mt19937 gen(rd());
+	uniform_int_distribution<uint8_t> distrib_ip(1, UINT8_MAX);
+	uniform_int_distribution<uint32_t> distrib_port(1, 65535);
+	uniform_int_distribution<uint32_t> distrib(1, UINT_MAX);
+	uint64_t val = distrib(gen);
+
+	static_assert(sizeof(XfwIpv6SynTuple) == 40);
+
+	for (unsigned int i = 0; i < OBJ_COUNT_MAX; i++) {
+		for (int j = 0; j < 16; j++) {
+			syn_xxhash_ip6[i].src_ip[j] = distrib_ip(gen);
+			syn_xxhash_ip6[i].dst_ip[j] = distrib_ip(gen);
+		}
+		syn_xxhash_ip6[i].seq = distrib(gen);
+		syn_xxhash_ip6[i].sport = distrib_port(gen);
+		syn_xxhash_ip6[i].dport = distrib_port(gen);
+	}
+
+	for (auto _ : state) {
+		idx++;
+		idx %= OBJ_COUNT_MAX;
+		__u64 hash = syn_xxh64_ipv6(&syn_xxhash_ip6[idx], val);
+		benchmark::DoNotOptimize(hash);
+	}
+}
+BENCHMARK(BM_syn_xxhash_ip6);
+
+static void
+BM_syn_jhash_ip6(benchmark::State& state)
+{
+	unsigned int idx = 0;
+	random_device rd;
+	mt19937 gen(rd());
+	uniform_int_distribution<uint8_t> distrib_ip(1, UINT8_MAX);
+	uniform_int_distribution<uint32_t> distrib_port(1, 65535);
+	uniform_int_distribution<uint32_t> distrib(1, UINT_MAX);
+	uint64_t val = distrib(gen);
+
+	static_assert(sizeof(XfwIpv6SynTuple) == 40);
+
+	for (unsigned int i = 0; i < OBJ_COUNT_MAX; i++) {
+		for (int j = 0; j < 16; j++) {
+			syn_jhash_ip6[i].src_ip[j] = distrib_ip(gen);
+			syn_jhash_ip6[i].dst_ip[j] = distrib_ip(gen);
+		}
+		syn_jhash_ip6[i].seq = distrib(gen);
+		syn_jhash_ip6[i].sport = distrib_port(gen);
+		syn_jhash_ip6[i].dport = distrib_port(gen);
+	}
+
+	for (auto _ : state) {
+		idx++;
+		idx %= OBJ_COUNT_MAX;
+		__u64 hash = jhash(&syn_jhash_ip6[idx],
+				   sizeof(XfwIpv6SynTuple), val);
+		benchmark::DoNotOptimize(hash);
+	}
+}
+BENCHMARK(BM_syn_jhash_ip6);
+
+BENCHMARK_MAIN();

--- a/benchmarks/jhash.h
+++ b/benchmarks/jhash.h
@@ -1,0 +1,226 @@
+/*
+ *	Tempesta xFW Jenkins hash implementation
+ *
+ * This file is based on the Linux kernel implementation of Jenkins hash
+ * (jhash), originally derived from Bob Jenkins' lookup3 algorithm.
+ *
+ * Original Linux kernel source:
+ *   include/linux/jhash.h
+ *
+ * Original algorithm:
+ *   https://burtleburtle.net/bob/hash/
+ *
+ * The code has been minimally adapted to allow building and running
+ * Tempesta xFW benchmarks in userspace:
+ * - Linux kernel dependencies removed;
+ * - userspace-compatible types and helpers used;
+ * - hash algorithm preserved.
+ *
+ * No functional changes to the hashing algorithm were intentionally made.
+ *
+ * SPDX-FileCopyrightText: © 2026 Tempesta Technologies, Inc.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+static inline uint32_t
+rol32(uint32_t word, unsigned int shift)
+{
+	return (word << shift) | (word >> (32 - shift));
+}
+
+static inline uint32_t
+__get_unaligned_cpu32(const void *p)
+{
+	const uint8_t *b = (const uint8_t *)p;
+
+	return ((uint32_t)b[0]) |
+	       ((uint32_t)b[1] << 8) |
+	       ((uint32_t)b[2] << 16) |
+	       ((uint32_t)b[3] << 24);
+}
+
+/* Best hash sizes are of power of two */
+#define jhash_size(n)   ((uint32_t)1<<(n))
+/* Mask the hash value, i.e (value & jhash_mask(n)) instead of (value % n) */
+#define jhash_mask(n)   (jhash_size(n)-1)
+
+/* __jhash_mix -- mix 3 32-bit values reversibly. */
+#define __jhash_mix(a, b, c)			\
+{						\
+	a -= c;  a ^= rol32(c, 4);  c += b;	\
+	b -= a;  b ^= rol32(a, 6);  a += c;	\
+	c -= b;  c ^= rol32(b, 8);  b += a;	\
+	a -= c;  a ^= rol32(c, 16); c += b;	\
+	b -= a;  b ^= rol32(a, 19); a += c;	\
+	c -= b;  c ^= rol32(b, 4);  b += a;	\
+}
+
+/* __jhash_final - final mixing of 3 32-bit values (a,b,c) into c */
+#define __jhash_final(a, b, c)			\
+{						\
+	c ^= b; c -= rol32(b, 14);		\
+	a ^= c; a -= rol32(c, 11);		\
+	b ^= a; b -= rol32(a, 25);		\
+	c ^= b; c -= rol32(b, 16);		\
+	a ^= c; a -= rol32(c, 4);		\
+	b ^= a; b -= rol32(a, 14);		\
+	c ^= b; c -= rol32(b, 24);		\
+}
+
+/* An arbitrary initial parameter */
+#define JHASH_INITVAL		0xdeadbeef
+
+/* jhash - hash an arbitrary key
+ * @k: sequence of bytes as key
+ * @length: the length of the key
+ * @initval: the previous hash, or an arbitray value
+ *
+ * The generic version, hashes an arbitrary sequence of bytes.
+ * No alignment or length assumptions are made about the input key.
+ *
+ * Returns the hash value of the key. The result depends on endianness.
+ */
+static inline uint32_t
+jhash(const void *key, uint32_t length, uint32_t initval)
+{
+	uint32_t a, b, c;
+	const uint8_t *k = (uint8_t *)key;
+
+	/* Set up the internal state */
+	a = b = c = JHASH_INITVAL + length + initval;
+
+	/* All but the last block: affect some 32 bits of (a,b,c) */
+	while (length > 12) {
+		a += __get_unaligned_cpu32(k);
+		b += __get_unaligned_cpu32(k + 4);
+		c += __get_unaligned_cpu32(k + 8);
+		__jhash_mix(a, b, c);
+		length -= 12;
+		k += 12;
+	}
+
+	/* Last block: affect all 32 bits of (c) */
+	switch (length) {
+	case 12:
+		c += (uint32_t)k[11] << 24;
+		__attribute__((fallthrough));
+	case 11:
+		c += (uint32_t)k[10] << 16;
+		__attribute__((fallthrough));
+	case 10:
+		c += (uint32_t)k[9] << 8;
+		__attribute__((fallthrough));
+	case 9:
+		c += k[8];
+		__attribute__((fallthrough));
+	case 8:
+		b += (uint32_t)k[7] << 24;
+		__attribute__((fallthrough));
+	case 7:
+		b += (uint32_t)k[6] << 16;
+		__attribute__((fallthrough));
+	case 6:
+		b += (uint32_t)k[5] << 8;
+		__attribute__((fallthrough));
+	case 5:
+		b += k[4];
+		__attribute__((fallthrough));
+	case 4:
+		a += (uint32_t)k[3] << 24;
+		__attribute__((fallthrough));
+	case 3:
+		a += (uint32_t)k[2] << 16;
+		__attribute__((fallthrough));
+	case 2:
+		a += (uint32_t)k[1] << 8;
+		__attribute__((fallthrough));
+	case 1:
+		a += k[0];
+		__jhash_final(a, b, c);
+		break;
+	case 0:
+		/* Nothing left to add */
+		break;
+	}
+
+	return c;
+}
+
+/* jhash2 - hash an array of uint32_t's
+ * @k: the key which must be an array of uint32_t's
+ * @length: the number of uint32_t's in the key
+ * @initval: the previous hash, or an arbitray value
+ *
+ * Returns the hash value of the key.
+ */
+static inline uint32_t
+jhash2(const uint32_t *k, uint32_t length, uint32_t initval)
+{
+	uint32_t a, b, c;
+
+	/* Set up the internal state */
+	a = b = c = JHASH_INITVAL + (length << 2) + initval;
+
+	/* Handle most of the key */
+	while (length > 3) {
+		a += k[0];
+		b += k[1];
+		c += k[2];
+		__jhash_mix(a, b, c);
+		length -= 3;
+		k += 3;
+	}
+
+	/* Handle the last 3 uint32_t's */
+	switch (length) {
+	case 3:
+		c += k[2];
+		__attribute__((fallthrough));
+	case 2:
+		b += k[1];
+		__attribute__((fallthrough));
+	case 1: a += k[0];
+		__jhash_final(a, b, c);
+		break;
+	case 0:	/* Nothing left to add */
+		break;
+	}
+
+	return c;
+}
+
+
+/* __jhash_nwords - hash exactly 3, 2 or 1 word(s) */
+static inline uint32_t
+__jhash_nwords(uint32_t a, uint32_t b, uint32_t c, uint32_t initval)
+{
+	a += initval;
+	b += initval;
+	c += initval;
+
+	__jhash_final(a, b, c);
+
+	return c;
+}
+
+static inline uint32_t
+jhash_3words(uint32_t a, uint32_t b, uint32_t c, uint32_t initval)
+{
+	return __jhash_nwords(a, b, c, initval + JHASH_INITVAL + (3 << 2));
+}
+
+static inline uint32_t
+jhash_2words(uint32_t a, uint32_t b, uint32_t initval)
+{
+	return __jhash_nwords(a, b, 0, initval + JHASH_INITVAL + (2 << 2));
+}
+
+static inline uint32_t
+jhash_1word(uint32_t a, uint32_t initval)
+{
+	return __jhash_nwords(a, 0, 0, initval + JHASH_INITVAL + (1 << 2));
+}

--- a/bpf/syn_hash.h
+++ b/bpf/syn_hash.h
@@ -1,0 +1,284 @@
+/*
+ *	Tempesta xFW SYN tuple XXH64 hashing
+ *
+ * This implementation provides XXH64-based hashing for TCP SYN
+ * tuple identification in eBPF/XDP programs.
+ *
+ * The hash algorithm is based on xxHash64 by Yann Collet.
+ *
+ * Original project:
+ *   https://github.com/Cyan4973/xxHash
+ *
+ * Reference implementation:
+ *   https://github.com/Cyan4973/xxHash/blob/dev/xxhash.c
+ *
+ * Implemented XXH64 primitives:
+ *
+ *   - XXH64_round()
+ *   - XXH64_mergeRound()
+ *   - XXH64_mergeAccs()
+ *   - XXH64_avalanche()
+ *
+ * Packet-specific hashing functions use fixed-size serialized
+ * TCP SYN tuples instead of the generic variable-length input
+ * processing used by the original implementation.
+ *
+ * Adaptation for eBPF:
+ *
+ *   - no dynamic memory allocation;
+ *   - no variable-length processing loops;
+ *   - explicit little-endian loads for packet data;
+ *   - verifier-friendly fixed-size operations.
+ *
+ * SPDX-FileCopyrightText: © 2026 Tempesta Technologies, Inc.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include "xxh64_hash.h"
+#include "../bpf_uapi/static_assert.h"
+
+typedef struct XfwIpv4SynTuple {
+	__u32 src_ip;
+	__u32 dst_ip;
+	__u32 seq;
+	__u16 sport;
+	__u16 dport;
+} XfwIpv4SynTuple;
+
+typedef struct XfwIpv6SynTuple {
+	__u8 src_ip[16];
+	__u8 dst_ip[16];
+	__u32 seq;
+	__u16 sport;
+	__u16 dport;
+} XfwIpv6SynTuple;
+
+/*
+ * Build the final 64-bit block:
+ *
+ *	TCP initial sequence number
+ *	source port
+ *	destination port
+ *
+ * Layout in memory:
+ *
+ * offset 0:
+ *	seq    (4 bytes)
+ *
+ * offset 4:
+ *	sport  (2 bytes)
+ *
+ * offset 6:
+ *	dport  (2 bytes)
+ *
+ * This corresponds to one XXH64 input block.
+ */
+static __always_inline __u64
+syn_ports_seq(__u16 sport, __u16 dport, __u32 seq)
+{
+	return (__u64)seq | ((__u64)sport << 32) | ((__u64)dport << 48);
+}
+
+/*
+ * Calculate xxHash64 for IPv4 SYN tuple.
+ *
+ * The serialized input layout is exactly 16 bytes:
+ *
+ * offset 0:
+ *	src_ip      (4 bytes)
+ *
+ * offset 4:
+ *	dst_ip      (4 bytes)
+ *
+ * offset 8:
+ *	seq         (4 bytes)
+ *
+ * offset 12:
+ *	sport       (2 bytes)
+ *
+ * offset 14:
+ *	dport       (2 bytes)
+ *
+ * The layout matches the memory representation of
+ * XfwIpv4SynTuple and therefore can be processed as two
+ * consecutive 64-bit little-endian input blocks.
+ *
+ * The original XXH64 implementation processes remaining
+ * input bytes in XXH64_finalize():
+ *
+ * Source:
+ *   https://github.com/Cyan4973/xxHash/blob/dev/xxhash.h
+ *
+ * Relevant code:
+ *
+ *	while (len >= 8) {
+ *		xxh_u64 const k1 = XXH64_round(0, XXH_get64bits(ptr));
+ *		ptr += 8;
+ *		hash ^= k1;
+ *		hash = XXH_rotl64(hash, 27) * XXH_PRIME64_1 + XXH_PRIME64_4;
+ *		len -= 8;
+ *	}
+ *
+ * Since the SYN tuple size is fixed (16 bytes), the generic
+ * xxHash loop is manually unrolled into two calls:
+ *
+ *	xxh64_update64(hash, first_8_bytes);
+ *	xxh64_update64(hash, second_8_bytes);
+ *
+ * The initial hash value follows XXH64_endian_align():
+ *
+ *	h64 = seed + XXH_PRIME64_5;
+ *	h64 += len;
+ *
+ * For a 16-byte input:
+ *
+ *	hash = seed + XXH_PRIME64_5 + 16;
+ *
+ * After all input blocks are processed, XXH64 applies the
+ * avalanche stage.
+ */
+static __always_inline __u64
+syn_xxh64_ipv4(XfwIpv4SynTuple *syn_tuple, __u64 seed)
+{
+	__u64 hash;
+	__u64 block;
+
+	STATIC_ASSERT(sizeof(XfwIpv4SynTuple) == 16,
+		      "XfwIpv4SynTuple size must be 16 bytes");
+
+	/*
+	 * Short input initialization.
+	 *
+	 * From XXH64_endian_align():
+	 *
+	 *     h64 = seed + PRIME64_5 + len
+	 */
+	hash = seed + XXH_PRIME64_5 + 16;
+
+	/* Construct first 8-byte block. */
+	block = (__u64)syn_tuple->src_ip | ((__u64)syn_tuple->dst_ip << 32);
+	hash = xxh64_update64(hash, block);
+
+	/* Construct second 8-byte block. */
+	block = syn_ports_seq(syn_tuple->sport, syn_tuple->dport,
+			      syn_tuple->seq);
+	hash = xxh64_update64(hash, block);
+
+	return xxh64_avalanche(hash);
+}
+
+/*
+ * Calculate XXH64 hash for IPv6 SYN tuple.
+ *
+ * Input size:
+ *
+ *	src IPv6     16 bytes
+ *	dst IPv6     16 bytes
+ *	seq           4 bytes
+ *	sport         2 bytes
+ *	dport         2 bytes
+ *
+ * Total:
+ *
+ *	40 bytes
+ *
+ * Because len >= 32, XXH64 does NOT use the short path.
+ *
+ * It uses:
+ *
+ *	XXH64_initAccs()
+ *	XXH64_consumeLong()
+ *	XXH64_mergeAccs()
+ *
+ * followed by XXH64_finalize().
+ */
+static __always_inline __u64
+syn_xxh64_ipv6(XfwIpv6SynTuple *syn_tuple, __u64 seed)
+{
+	__u64 acc[4];
+	__u64 hash;
+	__u64 block;
+
+	STATIC_ASSERT(sizeof(XfwIpv6SynTuple) == 40,
+		      "XfwIpv6SynTuple size must be 40 bytes");
+
+	/*
+	 * Long input initialization (see XXH64_endian_align()).
+	 *
+	 * For inputs >= 32 bytes, XXH64 uses the long-input path:
+	 *
+	 *	XXH64_initAccs(acc, seed);
+	 *
+	 *	Input blocks are processed by:
+	 *
+	 *	XXH64_consumeLong(acc, input, len, align);
+	 *
+	 *	After all 32-byte chunks are consumed, the four
+	 *	accumulators are merged:
+	 *
+	 *	h64 = XXH64_mergeAccs(acc);
+	 *
+	 * This implementation manually expands the fixed-size
+	 * operations required for the IPv6 SYN tuple instead of
+	 * using the generic variable-length loop.
+	 */
+	xxh64_init_accs(acc, seed);
+
+	/*
+	 * First 32 bytes:
+	 *
+	 * src IPv6 + dst IPv6
+	 *
+	 * Equivalent to four iterations of XXH64_consumeLong().
+	 */
+	block = xxh_load64_le(&syn_tuple->src_ip[0]);
+	acc[0] = xxh64_round(acc[0], block);
+
+	block = xxh_load64_le(&syn_tuple->src_ip[8]);
+	acc[1] = xxh64_round(acc[1], block);
+
+	block = xxh_load64_le(&syn_tuple->dst_ip[0]);
+	acc[2] = xxh64_round(acc[2], block);
+
+	block = xxh_load64_le(&syn_tuple->dst_ip[8]);
+	acc[3] = xxh64_round(acc[3], block);
+
+	hash = xxh64_merge_accs(acc);
+
+	/*
+	 * Add total input length.
+	 *
+	 * Source:
+	 *
+	 *     XXH64_endian_align()
+	 *
+	 * Original:
+	 *
+	 *     h64 += (xxh_u64)len;
+	 *
+	 * Total SYN tuple length is 40 bytes.
+	 */
+	hash += 40;
+
+	/*
+	 * Process the remaining 8 bytes.
+	 *
+	 * This corresponds to the first branch of
+	 * XXH64_finalize():
+	 *
+	 *	while (len >= 8) {
+	 *		...
+	 *	}
+	 *
+	 * The generic loop is replaced with a single
+	 * fixed-size operation because SYN tuple length
+	 * is known at compile time.
+	 */
+	block = syn_ports_seq(syn_tuple->sport, syn_tuple->dport,
+			      syn_tuple->seq);
+	hash = xxh64_update64(hash, block);
+
+	return xxh64_avalanche(hash);
+}

--- a/bpf/syn_hash.h
+++ b/bpf/syn_hash.h
@@ -40,19 +40,19 @@
 #include "../bpf_uapi/static_assert.h"
 
 typedef struct XfwIpv4SynTuple {
-	__u32 src_ip;
-	__u32 dst_ip;
-	__u32 seq;
-	__u16 sport;
-	__u16 dport;
+	uint32_t src_ip;
+	uint32_t dst_ip;
+	uint32_t seq;
+	uint16_t sport;
+	uint16_t dport;
 } XfwIpv4SynTuple;
 
 typedef struct XfwIpv6SynTuple {
-	__u8 src_ip[16];
-	__u8 dst_ip[16];
-	__u32 seq;
-	__u16 sport;
-	__u16 dport;
+	uint8_t	src_ip[16];
+	uint8_t dst_ip[16];
+	uint32_t seq;
+	uint16_t sport;
+	uint16_t dport;
 } XfwIpv6SynTuple;
 
 /*
@@ -75,10 +75,11 @@ typedef struct XfwIpv6SynTuple {
  *
  * This corresponds to one XXH64 input block.
  */
-static __always_inline __u64
-syn_ports_seq(__u16 sport, __u16 dport, __u32 seq)
+static __always_inline uint64_t
+syn_ports_seq(uint16_t sport, uint16_t dport, uint32_t seq)
 {
-	return (__u64)seq | ((__u64)sport << 32) | ((__u64)dport << 48);
+	return (uint64_t)seq | ((uint64_t)sport << 32) |
+		((uint64_t)dport << 48);
 }
 
 /*
@@ -139,11 +140,11 @@ syn_ports_seq(__u16 sport, __u16 dport, __u32 seq)
  * After all input blocks are processed, XXH64 applies the
  * avalanche stage.
  */
-static __always_inline __u64
-syn_xxh64_ipv4(XfwIpv4SynTuple *syn_tuple, __u64 seed)
+static __always_inline uint64_t
+syn_xxh64_ipv4(XfwIpv4SynTuple *syn_tuple, uint64_t seed)
 {
-	__u64 hash;
-	__u64 block;
+	uint64_t hash;
+	uint64_t block;
 
 	STATIC_ASSERT(sizeof(XfwIpv4SynTuple) == 16,
 		      "XfwIpv4SynTuple size must be 16 bytes");
@@ -158,7 +159,8 @@ syn_xxh64_ipv4(XfwIpv4SynTuple *syn_tuple, __u64 seed)
 	hash = seed + XXH_PRIME64_5 + 16;
 
 	/* Construct first 8-byte block. */
-	block = (__u64)syn_tuple->src_ip | ((__u64)syn_tuple->dst_ip << 32);
+	block = (uint64_t)syn_tuple->src_ip |
+		((uint64_t)syn_tuple->dst_ip << 32);
 	hash = xxh64_update64(hash, block);
 
 	/* Construct second 8-byte block. */
@@ -194,12 +196,12 @@ syn_xxh64_ipv4(XfwIpv4SynTuple *syn_tuple, __u64 seed)
  *
  * followed by XXH64_finalize().
  */
-static __always_inline __u64
-syn_xxh64_ipv6(XfwIpv6SynTuple *syn_tuple, __u64 seed)
+static __always_inline uint64_t
+syn_xxh64_ipv6(XfwIpv6SynTuple *syn_tuple, uint64_t seed)
 {
-	__u64 acc[4];
-	__u64 hash;
-	__u64 block;
+	uint64_t acc[4];
+	uint64_t hash;
+	uint64_t block;
 
 	STATIC_ASSERT(sizeof(XfwIpv6SynTuple) == 40,
 		      "XfwIpv6SynTuple size must be 40 bytes");

--- a/bpf/xxh64_hash.h
+++ b/bpf/xxh64_hash.h
@@ -63,7 +63,7 @@
  * acc[3] = seed - PRIME64_1;
  */
 static __always_inline void
-xxh64_init_accs(__u64 acc[4], __u64 seed)
+xxh64_init_accs(uint64_t acc[4], uint64_t seed)
 {
 	acc[0] = seed + XXH_PRIME64_1 + XXH_PRIME64_2;
 	acc[1] = seed + XXH_PRIME64_2;
@@ -80,13 +80,13 @@ xxh64_init_accs(__u64 acc[4], __u64 seed)
  *
  * from xxHash.
  */
-static __always_inline __u64
-xxh_load64_le(const __u8 *p)
+static __always_inline uint64_t
+xxh_load64_le(const uint8_t *p)
 {
-	return ((__u64)p[0]) | ((__u64)p[1] << 8) | ((__u64)p[2] << 16) |
-	       ((__u64)p[3] << 24) | ((__u64)p[4] << 32) |
-	       ((__u64)p[5] << 40) | ((__u64)p[6] << 48) |
-	       ((__u64)p[7] << 56);
+	return ((uint64_t)p[0]) | ((uint64_t)p[1] << 8) |
+	       ((uint64_t)p[2] << 16) | ((uint64_t)p[3] << 24) |
+	       ((uint64_t)p[4] << 32) | ((uint64_t)p[5] << 40) |
+	       ((uint64_t)p[6] << 48) | ((uint64_t)p[7] << 56);
 }
 
 /**
@@ -98,8 +98,8 @@ xxh_load64_le(const __u8 *p)
  * intrinsics, while eBPF uses the portable shift/or implementation
  * accepted by the verifier.
  */
-static __always_inline __u64
-xxh_rotl64(__u64 x, __u32 r)
+static __always_inline uint64_t
+xxh_rotl64(uint64_t x, uint32_t r)
 {
 	return (x << r) | (x >> (64 - r));
 }
@@ -117,8 +117,8 @@ xxh_rotl64(__u64 x, __u32 r)
  * acc = XXH_rotl64(acc,31);
  * acc *= PRIME64_1;
  */
-static __always_inline __u64
-xxh64_round(__u64 acc, __u64 input)
+static __always_inline uint64_t
+xxh64_round(uint64_t acc, uint64_t input)
 {
 	acc += input * XXH_PRIME64_2;
 	acc = xxh_rotl64(acc, 31);
@@ -140,8 +140,8 @@ xxh64_round(__u64 acc, __u64 input)
  * acc ^= val;
  * acc  = acc * XXH_PRIME64_1 + XXH_PRIME64_4;
  */
-static __always_inline __u64
-xxh64_merge_round(__u64 acc, __u64 val)
+static __always_inline uint64_t
+xxh64_merge_round(uint64_t acc, uint64_t val)
 {
 	val  = xxh64_round(0, val);
 	acc ^= val;
@@ -167,10 +167,10 @@ xxh64_merge_round(__u64 acc, __u64 val)
  * h64 = XXH64_mergeRound(h64, acc[2]);
  * h64 = XXH64_mergeRound(h64, acc[3]);
  */
-static __always_inline __u64
-xxh64_merge_accs(__u64 acc[4])
+static __always_inline uint64_t
+xxh64_merge_accs(uint64_t acc[4])
 {
-	__u64 h64;
+	uint64_t h64;
 
 	h64 = xxh_rotl64(acc[0], 1) + xxh_rotl64(acc[1], 7) +
 	      xxh_rotl64(acc[2], 12) + xxh_rotl64(acc[3], 18);
@@ -214,10 +214,10 @@ xxh64_merge_accs(__u64 acc[4])
  * required number of 64-bit block operations and avoid
  * variable-length processing.
  */
-static __always_inline __u64
-xxh64_update64(__u64 hash, __u64 input)
+static __always_inline uint64_t
+xxh64_update64(uint64_t hash, uint64_t input)
 {
-	const __u64 k1 = xxh64_round(0, input);
+	const uint64_t k1 = xxh64_round(0, input);
 
 	hash ^= k1;
 	hash = xxh_rotl64(hash, 27) * XXH_PRIME64_1 + XXH_PRIME64_4;
@@ -240,8 +240,8 @@ xxh64_update64(__u64 hash, __u64 input)
  * h *= PRIME64_3;
  * h ^= h >> 32;
  */
-static __always_inline __u64
-xxh64_avalanche(__u64 h)
+static __always_inline uint64_t
+xxh64_avalanche(uint64_t h)
 {
 	h ^= h >> 33;
 	h *= XXH_PRIME64_2;

--- a/bpf/xxh64_hash.h
+++ b/bpf/xxh64_hash.h
@@ -1,0 +1,253 @@
+/*
+ *	Tempesta xFW XXH64 implementation
+ *
+ * This implementation is based on the xxHash algorithm
+ * by Yann Collet and adapted for eBPF/XDP usage.
+ *
+ * The implementation follows the XXH64 reference algorithm,
+ * including short and long input processing primitives:
+ * - XXH64_round();
+ * - XXH64_mergeRound();
+ * - XXH64_mergeAccs();
+ * - XXH64_avalanche().
+ *
+ * Packet-specific users can build fixed-size hashing paths
+ * without generic variable-length processing required by
+ * the original implementation.
+ *
+ * Original project:
+ *   https://github.com/Cyan4973/xxHash
+ *
+ * The code is adapted for eBPF environment:
+ * - no dynamic memory allocation;
+ * - no variable-length processing loops;
+ * - fixed-size packet tuple hashing;
+ * - verifier-friendly operations.
+ *
+ * SPDX-FileCopyrightText: © 2026 Tempesta Technologies, Inc.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+#pragma once
+
+#ifdef BPF_PROGRAM
+#include "vmlinux.h"
+#else
+#include <linux/types.h>
+#endif
+
+/**
+ * xxHash64 prime constants.
+ *
+ * Source:
+ *	xxhash.h
+ *	XXH_PRIME64_*
+ */
+#define XXH_PRIME64_1 0x9E3779B185EBCA87ULL
+#define XXH_PRIME64_2 0xC2B2AE3D27D4EB4FULL
+#define XXH_PRIME64_3 0x165667B19E3779F9ULL
+#define XXH_PRIME64_4 0x85EBCA77C2B2AE63ULL
+#define XXH_PRIME64_5 0x27D4EB2F165667C5ULL
+
+/**
+ * Initialize four accumulators.
+ *
+ * Source:
+ *	xxhash.h
+ *	XXH64_initAccs()
+ *
+ * Original:
+ *
+ * acc[0] = seed + PRIME64_1 + PRIME64_2;
+ * acc[1] = seed + PRIME64_2;
+ * acc[2] = seed + 0;
+ * acc[3] = seed - PRIME64_1;
+ */
+static __always_inline void
+xxh64_init_accs(__u64 acc[4], __u64 seed)
+{
+	acc[0] = seed + XXH_PRIME64_1 + XXH_PRIME64_2;
+	acc[1] = seed + XXH_PRIME64_2;
+	acc[2] = seed;
+	acc[3] = seed - XXH_PRIME64_1;
+}
+
+/**
+ * Load 8 bytes as little-endian uint64.
+ *
+ * This replaces:
+ *
+ *	XXH_get64bits(ptr)
+ *
+ * from xxHash.
+ */
+static __always_inline __u64
+xxh_load64_le(const __u8 *p)
+{
+	return ((__u64)p[0]) | ((__u64)p[1] << 8) | ((__u64)p[2] << 16) |
+	       ((__u64)p[3] << 24) | ((__u64)p[4] << 32) |
+	       ((__u64)p[5] << 40) | ((__u64)p[6] << 48) |
+	       ((__u64)p[7] << 56);
+}
+
+/**
+ * Rotate left operation.
+ *
+ * Equivalent to XXH_rotl64() from xxHash reference implementation.
+ *
+ * The xxHash userspace implementation selects architecture-specific
+ * intrinsics, while eBPF uses the portable shift/or implementation
+ * accepted by the verifier.
+ */
+static __always_inline __u64
+xxh_rotl64(__u64 x, __u32 r)
+{
+	return (x << r) | (x >> (64 - r));
+}
+
+/**
+ * xxHash64 mixing round.
+ *
+ * Source:
+ *	xxhash.h
+ *	XXH64_round()
+ *
+ * Original code:
+ *
+ * acc += input * PRIME64_2;
+ * acc = XXH_rotl64(acc,31);
+ * acc *= PRIME64_1;
+ */
+static __always_inline __u64
+xxh64_round(__u64 acc, __u64 input)
+{
+	acc += input * XXH_PRIME64_2;
+	acc = xxh_rotl64(acc, 31);
+	acc *= XXH_PRIME64_1;
+
+	return acc;
+}
+
+/**
+ * Merge one accumulator into the final XXH64 hash state.
+ *
+ * Source:
+ *	xxhash.h
+ *	XXH64_mergeRound()
+ *
+ * Original:
+ *
+ * val  = XXH64_round(0, val);
+ * acc ^= val;
+ * acc  = acc * XXH_PRIME64_1 + XXH_PRIME64_4;
+ */
+static __always_inline __u64
+xxh64_merge_round(__u64 acc, __u64 val)
+{
+	val  = xxh64_round(0, val);
+	acc ^= val;
+	acc  = acc * XXH_PRIME64_1 + XXH_PRIME64_4;
+
+	return acc;
+}
+
+/**
+ * Merge four accumulators.
+ *
+ * Source:
+ *	xxhash.h
+ *	XXH64_mergeAccs()
+ *
+ * Original:
+ *
+ * h64 = rotl(acc[0],1) + rotl(acc[1],7)
+ *       + rotl(acc[2],12) + rotl(acc[3],18);
+ *
+ * h64 = XXH64_mergeRound(h64, acc[0]);
+ * h64 = XXH64_mergeRound(h64, acc[1]);
+ * h64 = XXH64_mergeRound(h64, acc[2]);
+ * h64 = XXH64_mergeRound(h64, acc[3]);
+ */
+static __always_inline __u64
+xxh64_merge_accs(__u64 acc[4])
+{
+	__u64 h64;
+
+	h64 = xxh_rotl64(acc[0], 1) + xxh_rotl64(acc[1], 7) +
+	      xxh_rotl64(acc[2], 12) + xxh_rotl64(acc[3], 18);
+
+	h64 = xxh64_merge_round(h64, acc[0]);
+	h64 = xxh64_merge_round(h64, acc[1]);
+	h64 = xxh64_merge_round(h64, acc[2]);
+	h64 = xxh64_merge_round(h64, acc[3]);
+
+	return h64;
+}
+
+/**
+ * Process one 64-bit input block.
+ *
+ * This helper extracts the 8-byte processing step from
+ * XXH64_finalize() in the xxHash reference implementation.
+ *
+ * Original source:
+ *   https://github.com/Cyan4973/xxHash/blob/dev/xxhash.c
+ *
+ * Original code from XXH64_finalize():
+ *
+ *	while (len >= 8) {
+ *		xxh_u64 const k1 = XXH64_round(0, XXH_get64bits(ptr));
+ *
+ *		ptr += 8;
+ *		hash ^= k1;
+ *		hash = XXH_rotl64(hash, 27) * XXH_PRIME64_1 + XXH_PRIME64_4;
+ *		len -= 8;
+ *	}
+ *
+ * This implementation replaces XXH_get64bits(ptr) with
+ * a pre-packed 64-bit input value. The caller must ensure
+ * that the value has the same little-endian byte layout as
+ * the original input buffer.
+ *
+ * The generic xxHash implementation processes arbitrary-size
+ * input using a loop. For SYN flood protection the hashed
+ * tuple size is known in advance, so eBPF code can unroll the
+ * required number of 64-bit block operations and avoid
+ * variable-length processing.
+ */
+static __always_inline __u64
+xxh64_update64(__u64 hash, __u64 input)
+{
+	const __u64 k1 = xxh64_round(0, input);
+
+	hash ^= k1;
+	hash = xxh_rotl64(hash, 27) * XXH_PRIME64_1 + XXH_PRIME64_4;
+	
+	return hash;
+}
+
+/*
+ * Final avalanche step.
+ *
+ * Source:
+ *	xxhash.h
+ *	XXH64_avalanche()
+ *
+ * Original code:
+ *
+ * h ^= h >> 33;
+ * h *= PRIME64_2;
+ * h ^= h >> 29;
+ * h *= PRIME64_3;
+ * h ^= h >> 32;
+ */
+static __always_inline __u64
+xxh64_avalanche(__u64 h)
+{
+	h ^= h >> 33;
+	h *= XXH_PRIME64_2;
+	h ^= h >> 29;
+	h *= XXH_PRIME64_3;
+	h ^= h >> 32;
+
+	return h;
+}

--- a/lib/t/Makefile
+++ b/lib/t/Makefile
@@ -2,7 +2,9 @@
 #
 # SPDX-FileCopyrightText: © 2026 Tempesta Technologies, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
+
 OBJ_DIR = BUILD
+TARGET:= $(OBJ_DIR)/utest
 
 # GoogleTest source directory (you might need to manually compile gtest-all.cc)
 GTEST_DIR = /usr/src/gtest
@@ -22,14 +24,14 @@ LDFLAGS	+=  -L/$(BUILD_LIBDIR)
 CXXFLAGS += -I/usr/include/gtest -pthread
 INCLUDES += -I$(BUILD_INCLUDE)
 
-.PHONY: build utest install clean test
+.PHONY: build install clean test
 
 # Main target for building the test binary
-build: $(OBJ_DIR)/utest
+build: $(TARGET)
 
 # Build the test binary and link with GoogleTest
-$(OBJ_DIR)/utest: $(OBJECTS) $(GTEST_OBJ)
-	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lgrpc++ -ltfwcli -lxxhash -lproto $(GTEST_LIBS) -Wl,-rpath,'$$ORIGIN/../../../BUILD/lib'
+$(TARGET): $(OBJECTS) $(GTEST_OBJ)
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lgrpc++ -ltfwcli -lproto $(GTEST_LIBS) -Wl,-rpath,'$$ORIGIN/../../../BUILD/lib'
 
 # Build object files from source files
 $(OBJ_DIR)/%.o: %.cc
@@ -41,16 +43,16 @@ $(GTEST_OBJ):
 	@mkdir -p $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) -I$(GTEST_DIR) -c $(GTEST_SRC) -o $@
 
-clean : FORCE
-	@rm -rf $(OBJ_DIR) utest
+clean: FORCE
+	@rm -rf $(OBJ_DIR)
 
 install:
 
 -include $(DEPS)
 
 # You can call utest with "-v" or "--verbose" to get all debug output.
-test: utest
+test:
 	@echo $(BUILD_DIR)
-	@$(OBJ_DIR)/utest
+	@$(TARGET)
 
-FORCE :
+FORCE:

--- a/lib/t/Makefile
+++ b/lib/t/Makefile
@@ -29,7 +29,7 @@ build: $(OBJ_DIR)/utest
 
 # Build the test binary and link with GoogleTest
 $(OBJ_DIR)/utest: $(OBJECTS) $(GTEST_OBJ)
-	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lgrpc++ -ltfwcli -lproto $(GTEST_LIBS) -Wl,-rpath,'$$ORIGIN/../../../BUILD/lib'
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lgrpc++ -ltfwcli -lxxhash -lproto $(GTEST_LIBS) -Wl,-rpath,'$$ORIGIN/../../../BUILD/lib'
 
 # Build object files from source files
 $(OBJ_DIR)/%.o: %.cc

--- a/lib/t/syn_hash.cc
+++ b/lib/t/syn_hash.cc
@@ -1,0 +1,47 @@
+#include <gtest/gtest.h>
+#include <xxhash.h>
+
+extern "C" {
+#include "../../bpf/syn_hash.h"
+}
+
+TEST(Xxh64SynHash, IPv4GoldenVector)
+{
+	XfwIpv4SynTuple tuple = {
+		.src_ip = 0x01020304,
+		.dst_ip = 0x05060708,
+		.seq = 0x11223344,
+		.sport = 12345,
+		.dport = 443,
+	};
+	auto hash = syn_xxh64_ipv4(&tuple, 0);
+	auto ref_hash = XXH64(&tuple, sizeof(tuple), 0);
+
+	ASSERT_EQ(hash, ref_hash);
+}
+
+
+TEST(Xxh64SynHash, IPv6GoldenVector)
+{
+	XfwIpv6SynTuple tuple = {
+		.src_ip = {
+			0x20, 0x01, 0x0d, 0xb8,
+			0, 0, 0, 0,
+			0, 0, 0, 0,
+			0, 0, 0, 1
+		},
+		.dst_ip = {
+			0x20, 0x01, 0x0d, 0xb8,
+			0, 0, 0, 0,
+			0, 0, 0, 0,
+			0, 0, 0, 2
+		},
+		.seq = 0x11223344,
+		.sport = 12345,
+		.dport = 443,
+	};
+	auto hash = syn_xxh64_ipv6(&tuple, 0);
+	auto ref_hash = XXH64(&tuple, sizeof(tuple), 0);
+
+	ASSERT_EQ(hash, ref_hash);
+}

--- a/t/Makefile
+++ b/t/Makefile
@@ -1,0 +1,32 @@
+#	Tempesta xFW tests
+#
+# SPDX-FileCopyrightText: © 2026 Tempesta Technologies, Inc.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+SUBDIRS := bpf
+
+build: $(SUBDIRS)
+
+.PHONY: $(SUBDIRS)
+
+bpf:
+	@$(MAKE) -C bpf build
+
+clean: FORCE
+	@for dir in $(SUBDIRS); do \
+		echo "Cleaning $$dir..."; \
+		$(MAKE) -C $$dir clean; \
+	done
+
+install:
+	@for dir in $(SUBDIRS); do \
+		echo "Installing $$dir..."; \
+		$(MAKE) -C $$dir install; \
+	done
+
+test:
+	@for dir in $(SUBDIRS); do \
+		$(MAKE) -C $$dir test; \
+	done
+
+FORCE:

--- a/t/bpf/Makefile
+++ b/t/bpf/Makefile
@@ -1,0 +1,50 @@
+#
+# Tempesta xFW eBPF tests
+#
+# SPDX-FileCopyrightText: © 2026 Tempesta Technologies, Inc.
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+OBJ_DIR := BUILD
+TARGET  := $(OBJ_DIR)/utest
+
+GTEST_DIR := /usr/src/gtest
+GTEST_SRC := $(GTEST_DIR)/src/gtest-all.cc
+GTEST_OBJ := $(OBJ_DIR)/gtest-all.o
+
+SOURCES := $(wildcard *.cc)
+OBJECTS := $(patsubst %.cc,$(OBJ_DIR)/%.o,$(SOURCES))
+DEPS    := $(OBJECTS:.o=.d)
+
+CPPFLAGS += -I/usr/include/gtest
+CPPFLAGS += -I$(GTEST_DIR)
+CPPFLAGS += -I..
+CPPFLAGS += -I../..
+
+.PHONY: build test clean install
+
+build: $(TARGET)
+
+$(TARGET): $(OBJECTS) $(GTEST_OBJ)
+	$(CXX) -o $@ $^ $(LDFLAGS) $(LDLIBS) -lxxhash
+
+$(OBJ_DIR)/%.o: %.cc
+	@mkdir -p $(dir $@)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -MMD -MP -c $< -o $@
+
+$(GTEST_OBJ): $(GTEST_SRC)
+	@mkdir -p $(dir $@)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
+
+clean: FORCE
+	rm -rf $(OBJ_DIR)
+
+install:
+
+-include $(DEPS)
+
+test:
+	@echo $(BUILD_DIR)
+	$(TARGET)
+
+FORCE :

--- a/t/bpf/bpf_tests.cc
+++ b/t/bpf/bpf_tests.cc
@@ -1,0 +1,16 @@
+/**
+ *	Tempesta Client library private definitions
+ *
+ * SPDX-FileCopyrightText: © 2026 Tempesta Technologies, Inc.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <cstring>
+#include <gtest/gtest.h>
+
+int
+main(int argc, char **argv)
+{
+	::testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}

--- a/t/bpf/syn_hash.cc
+++ b/t/bpf/syn_hash.cc
@@ -20,7 +20,6 @@ TEST(Xxh64SynHash, IPv4GoldenVector)
 	ASSERT_EQ(hash, ref_hash);
 }
 
-
 TEST(Xxh64SynHash, IPv6GoldenVector)
 {
 	XfwIpv6SynTuple tuple = {


### PR DESCRIPTION
Implement XXH64 hashing for IPv4 and IPv6 SYN tuples. The implementation follows the xxHash reference algorithm and is adapted for eBPF/XDP usage with fixed-size inputs and verifier-friendly operations.
Add unit tests to verify hash calculation against the reference implementation.

Part-of: SYN flood protection for scrubbing mode