### PR TITLE
Support all IP protocol numbers

### DIFF
--- a/bpf/compiler.h
+++ b/bpf/compiler.h
@@ -13,6 +13,10 @@
 
 #include "../bpf_uapi/static_assert.h"
 
+#ifndef UINT8_MAX
+#define UINT8_MAX		255
+#endif
+
 #ifndef UINT64_MAX
 #define UINT64_MAX		18446744073709551615ULL
 #endif

--- a/bpf_uapi/supported_protocols.h
+++ b/bpf_uapi/supported_protocols.h
@@ -8,6 +8,7 @@
 #pragma once
 #ifdef BPF_PROGRAM
 #include "vmlinux.h"
+#include "../bpf/compiler.h"
 #else
 #include <cstdint>
 #endif
@@ -20,5 +21,9 @@ enum XfwSupportedProtocols : uint8_t {
 	XFW_L4_PROTO_UDP		= IPPROTO_UDP,
 	XFW_L4_PROTO_GRE		= IPPROTO_GRE,
 	XFW_L4_PROTO_ICMPV6		= IPPROTO_ICMPV6,
-	XFW_SUPPORTED_PROTOCOL_MAX
+	/*
+	 * The IPv4 Protocol and IPv6 Next Header fields are 8 bits wide
+	 * (RFC 791, RFC 8200), so there are 256 possible protocol values.
+	 */
+	XFW_SUPPORTED_PROTOCOL_MAX	= UINT8_MAX
 };

--- a/lib/cli/ip_proto_section.cc
+++ b/lib/cli/ip_proto_section.cc
@@ -45,17 +45,9 @@ IpProtoSection::IpProtoSection::process_body()
 		return {false, nullptr};
 
 	const auto num = parsing_helpers::parse_as<uint32_t>(nv);
+	if (num > XFW_SUPPORTED_PROTOCOL_MAX)
+		throw Except("Unknown protocol {} in ip_proto section", num);
 	const auto e = static_cast<XfwSupportedProtocols>(num);
-	switch (e) {
-		case XfwSupportedProtocols::XFW_L4_PROTO_ICMP: break;
-		case XfwSupportedProtocols::XFW_L4_PROTO_TCP: break;
-		case XfwSupportedProtocols::XFW_L4_PROTO_UDP: break;
-		case XfwSupportedProtocols::XFW_L4_PROTO_GRE: break;
-		case XfwSupportedProtocols::XFW_L4_PROTO_ICMPV6: break;
-		default:
-			throw Except("Unknown protocol {} in ip_proto section", num);
-	}
-
 	if (!ip_proto_)
 		ip_proto_.emplace();
 

--- a/lib/t/ip_proto.cc
+++ b/lib/t/ip_proto.cc
@@ -5,16 +5,48 @@
 #include "../../lib/proto/serialize.hh"
 #include "../../lib/cli/tcl_private.hh"
 
-TEST(RejectsXfwConfig, WithUnsupportedProtocol)
+TEST(RejectsXfwConfig, WithUnsupportedProtocolPositive)
 {
-	std::string prog = "xfw{ip_proto {2} }";
+	std::string prog = "xfw{ip_proto {256} }";
+	std::unique_ptr<TlProgConf> conf(tcl_parse_full_conf(prog.c_str(), prog.length()));
+	ASSERT_TRUE(!conf);
+}
+
+TEST(RejectsXfwConfig, WithUnsupportedProtocolNegative)
+{
+	std::string prog = "xfw{ip_proto {-1} }";
 	std::unique_ptr<TlProgConf> conf(tcl_parse_full_conf(prog.c_str(), prog.length()));
 	ASSERT_TRUE(!conf);
 }
 
 TEST(ParsesXfwConfig, WithAllSupportedProtocols)
 {
-	std::string prog = "xfw{ip_proto {1, 6, 17, 47, 58} }";
+	std::string prog = "xfw{ip_proto {"
+		"1, 2, 3, 4, 5, 6, 7, 8, 9, 10,"
+		"11, 12, 13, 14, 15, 16, 17, 18, 19, 20,"
+		"21, 22, 23, 24, 25, 26, 27, 28, 29, 30,"
+		"41, 42, 43, 44, 45, 46, 47, 48, 49, 50,"
+		"51, 52, 53, 54, 55, 56, 57, 58, 59, 60,"
+		"61, 62, 63, 64, 65, 66, 67, 68, 69, 70,"
+		"81, 82, 83, 84, 85, 86, 87, 88, 89, 90,"
+		"91, 92, 93, 94, 95, 96, 97, 98, 99, 100,"
+		"101, 102, 103, 104, 105, 106, 107, 108, 109, 110,"
+		"111, 112, 113, 114, 115, 116, 117, 118, 119, 120,"
+		"121, 122, 123, 124, 125, 126, 127, 128, 129, 130,"
+		"131, 132, 133, 134, 135, 136, 137, 138, 139, 140,"
+		"141, 142, 143, 144, 145, 146, 147, 148, 149, 150,"
+		"151, 152, 153, 154, 155, 156, 157, 158, 159, 160,"
+		"161, 162, 163, 164, 165, 166, 167, 168, 169, 170,"
+		"171, 172, 173, 174, 175, 176, 177, 178, 179, 180,"
+		"181, 182, 183, 184, 185, 186, 187, 188, 189, 190,"
+		"191, 192, 193, 194, 195, 196, 197, 198, 199, 200,"
+		"201, 202, 203, 204, 205, 206, 207, 208, 209, 210,"
+		"211, 212, 213, 214, 215, 216, 217, 218, 219, 220,"
+		"221, 222, 223, 224, 225, 226, 227, 228, 229, 230,"
+		"231, 232, 233, 234, 235, 236, 237, 238, 239, 240,"
+		"241, 242, 243, 244, 245, 246, 247, 248, 249, 250,"
+		"251, 252, 253, 254, 255"
+	"} }";
 	std::unique_ptr<TlProgConf> conf(tcl_parse_full_conf(prog.c_str(), prog.length()));
 	ASSERT_TRUE(conf);
 	ASSERT_TRUE(conf->prvt);

--- a/t/func/tests/test_ip_proto.py
+++ b/t/func/tests/test_ip_proto.py
@@ -1,6 +1,11 @@
 # SPDX-FileCopyrightText: (c) 2026 Tempesta Technologies, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
+from asyncio import gather
+
 import pytest
+from scapy.all import Raw
+from scapy.layers.inet import ETH_P_IP, IP, UDP
+from scapy.layers.l2 import Ether
 
 
 async def test_block_by_default_gre(
@@ -124,3 +129,48 @@ async def test_ignore_internal_packets(
     server_packet = getattr(gre_raw_server, packet_method)("pong")
     await gre_raw_server.send_packet(server_packet)
     await gre_raw_client.receive_expected_packet(server_packet)
+
+
+@pytest.mark.parametrize(
+    "protocol",
+    [
+        pytest.param(0, id="min"),
+        pytest.param(100, id="arbitrary"),
+        pytest.param(253, id="experimental"),
+        pytest.param(255, id="max"),
+    ],
+)
+async def test_allow_arbitrary_ip_protocol(
+    xfw,
+    ether_raw_client,
+    ether_raw_server,
+    flush_arp_cache,
+    protocol: int,
+):
+    """Verify that xFW allows arbitrary IPv4 protocol numbers in range 0..255."""
+    await ether_raw_server.start()
+    await ether_raw_client.start()
+
+    src_mac, dst_mac = await gather(
+        ether_raw_client.get_mac_address(),
+        ether_raw_server.get_mac_address(),
+    )
+
+    packet = (
+        Ether(dst=dst_mac, src=src_mac, type=ETH_P_IP)
+        / IP(
+            src=ether_raw_client.ip,
+            dst=ether_raw_server.ip,
+            proto=protocol,
+        )
+        / Raw(b"payload")
+    )
+
+    await xfw.rules_set(f"xfw {{ ip_proto {{ {protocol} }} }}")
+
+    await ether_raw_client.send_packet(packet)
+
+    received = await ether_raw_server.receive_packet()
+    assert received is not None
+    assert received[IP].proto == protocol
+    assert bytes(received[Raw].load) == b"payload"


### PR DESCRIPTION
The IPv4 Protocol and IPv6 Next Header fields are 8 bits wide, so allow the ip_proto configuration to accept the full 0..255 range instead of limiting it to the protocols explicitly handled by xFW.

Reject protocol numbers outside the valid range and extend unit tests to cover all supported values and invalid boundaries.

Add a functional test with raw IPv4 packets to verify that arbitrary configured protocol numbers are allowed by the datapath.