### PR TITLE
Fix flacky test

### DIFF
--- a/t/func/framework/asyn/ether_raw_client.py
+++ b/t/func/framework/asyn/ether_raw_client.py
@@ -6,9 +6,16 @@ import socket
 from typing import Optional
 
 from scapy.all import Raw
-from scapy.layers.l2 import Ether
+from scapy.layers.inet6 import ICMPv6ND_NA, ICMPv6ND_NS
+from scapy.layers.l2 import ARP, Ether
 
 from framework.stateful import SocketBaseNetworkStateful
+
+_SYSTEM_LAYERS = (
+    ARP,  # IPv4 ARP
+    ICMPv6ND_NS,  # IPv6 Neighbor Solicitation
+    ICMPv6ND_NA,  # IPv6 Neighbor Advertisement
+)
 
 
 class EtherRawClient(SocketBaseNetworkStateful):
@@ -52,14 +59,21 @@ class EtherRawClient(SocketBaseNetworkStateful):
         Receive raw network data and reconstruct it into a Scapy packet.
 
         Retrieves raw binary data from the network using the internal low-level
-        `_receive` method.
+        `_receive` method
+
+        Skip system packets.
         """
         raw_data = await self._receive()
 
         if raw_data is None:
             return None
 
-        return self.decode_data(raw_data)
+        packet = self.decode_data(raw_data)
+
+        # we should skip system packets like ARP for ICMP
+        if any(packet.haslayer(layer) for layer in _SYSTEM_LAYERS):
+            return await self.receive_packet()
+        return packet
 
     async def set_sock_proto(self, proto: int):
         self.socket_proto = proto

--- a/t/func/tests/test_ip_proto.py
+++ b/t/func/tests/test_ip_proto.py
@@ -172,5 +172,6 @@ async def test_allow_arbitrary_ip_protocol(
 
     received = await ether_raw_server.receive_packet()
     assert received is not None
+    assert received.haslayer(IP), received
     assert received[IP].proto == protocol
     assert bytes(received[Raw].load) == b"payload"

--- a/t/func/tests/test_ip_proto.py
+++ b/t/func/tests/test_ip_proto.py
@@ -131,6 +131,19 @@ async def test_ignore_internal_packets(
     await gre_raw_client.receive_expected_packet(server_packet)
 
 
+async def receive_ipv4_packet(server, src, dst):
+    while True:
+        packet = await server.receive_packet()
+        if packet is None:
+            return None
+
+        if IP not in packet:
+            continue
+
+        if packet[IP].src == src and packet[IP].dst == dst:
+            return packet
+
+
 @pytest.mark.parametrize(
     "protocol",
     [
@@ -170,7 +183,11 @@ async def test_allow_arbitrary_ip_protocol(
 
     await ether_raw_client.send_packet(packet)
 
-    received = await ether_raw_server.receive_packet()
+    received = await receive_ipv4_packet(
+        ether_raw_server,
+        ether_raw_client.ip,
+        ether_raw_server.ip,
+    )
     assert received is not None
     assert received[IP].proto == protocol
     assert bytes(received[Raw].load) == b"payload"

--- a/t/func/tests/test_ip_proto.py
+++ b/t/func/tests/test_ip_proto.py
@@ -131,19 +131,6 @@ async def test_ignore_internal_packets(
     await gre_raw_client.receive_expected_packet(server_packet)
 
 
-async def receive_ipv4_packet(server, src, dst):
-    while True:
-        packet = await server.receive_packet()
-        if packet is None:
-            return None
-
-        if IP not in packet:
-            continue
-
-        if packet[IP].src == src and packet[IP].dst == dst:
-            return packet
-
-
 @pytest.mark.parametrize(
     "protocol",
     [
@@ -183,11 +170,7 @@ async def test_allow_arbitrary_ip_protocol(
 
     await ether_raw_client.send_packet(packet)
 
-    received = await receive_ipv4_packet(
-        ether_raw_server,
-        ether_raw_client.ip,
-        ether_raw_server.ip,
-    )
+    received = await ether_raw_server.receive_packet()
     assert received is not None
     assert received[IP].proto == protocol
     assert bytes(received[Raw].load) == b"payload"


### PR DESCRIPTION
The arbitrary IP protocol test could occasionally receive unrelated network traffic, such as IPv6 MLD multicast packets, instead of the packet sent by the test. This made the test flaky and caused IndexError: Layer [IP] not found when it attempted to access the IPv4 layer.

Add a helper to skip unrelated packets and wait for an IPv4 packet matching the expected source and destination addresses.