### PR TITLE
tcp auth: track connections by full TCP 4-tuple

### DIFF
--- a/bpf/ctx.h
+++ b/bpf/ctx.h
@@ -75,7 +75,6 @@ typedef struct XfwGlobalCtx {
 		struct udphdr	*uh;
 	};
 	uint64_t	ts_jiff;
-	XfwIp		ilog_addr;
 } XfwGlobalCtx;
 
 /* Read-only for eBPF. */

--- a/bpf/dns.h
+++ b/bpf/dns.h
@@ -96,7 +96,6 @@ typedef struct XfwDnsCtx {
 	XfwMd		*ctx;
 	XfwPerCpuStats	*g_stats;
 	XfwHdrCursor	hdr_cur;
-	XfwIp		ilog_addr;
 	uint32_t	pkt_sz;
 } XfwDnsCtx;
 
@@ -216,7 +215,8 @@ struct {
 } MAP_DNS_EGR_FD_REF SEC(".maps");
 
 static __always_inline int
-process_ingress_dns_query(XfwDnsCtx *dns_ctx, const XfwDnsHdr *dh)
+process_ingress_dns_query(XfwDnsCtx *dns_ctx, const XfwTcpConnKey *key,
+			  const XfwDnsHdr *dh)
 {
 	XfwDnsQRec *dq;
 
@@ -229,8 +229,9 @@ process_ingress_dns_query(XfwDnsCtx *dns_ctx, const XfwDnsHdr *dh)
 		return XFW_CTX_CONTINUE;
 
 	if (rcode != RCODE_OK)
-		return XFW_MAKE_CTX_DROP_EXT(dns_ctx, XFW_DNS_QRY_RCODE_NOT_OK,
-					     ": %u", rcode);
+		return XFW_MAKE_DROP_EXT(&key->src_addr, dns_ctx->pkt_sz,
+					 XFW_DNS_QRY_RCODE_NOT_OK,
+					 ": %u", rcode);
 
 	/*
 	 * Assume EDNS-only message.
@@ -242,16 +243,19 @@ process_ingress_dns_query(XfwDnsCtx *dns_ctx, const XfwDnsHdr *dh)
 
 	/* We don't support multiple DNS queries - it's quite rare case */
 	if (dh->qdcount != bpf_htons(1))
-		return XFW_MAKE_CTX_DROP(dns_ctx, XFW_DNS_MULTIPLE_QUESTIONS);
+		return XFW_MAKE_DROP(&key->src_addr, dns_ctx->pkt_sz,
+				     XFW_DNS_MULTIPLE_QUESTIONS);
 
 	dq = parse_single_dns_question(dns_ctx->ctx, &dns_ctx->hdr_cur, dh);
 	if (dq == NULL)
-		return XFW_MAKE_CTX_DROP(dns_ctx, XFW_DNS_BAD_QUESTION);
+		return XFW_MAKE_DROP(&key->src_addr, dns_ctx->pkt_sz,
+				     XFW_DNS_BAD_QUESTION);
 
 	if (unlikely(dh->nscount != 0))
-		return XFW_MAKE_CTX_DROP_EXT(dns_ctx, XFW_DNS_ANS_OR_AUTHS_IN_QUERY,
-					     ": nscount = %u",
-					     bpf_ntohs(dh->nscount));
+		return XFW_MAKE_DROP_EXT(&key->src_addr, dns_ctx->pkt_sz,
+					 XFW_DNS_ANS_OR_AUTHS_IN_QUERY,
+					 ": nscount = %u",
+					 bpf_ntohs(dh->nscount));
 
 	if (dq->qtype == bpf_ntohs(QTYPE_IXFR)) {
 		/* XXX: should we pass it without further validation? */
@@ -263,17 +267,19 @@ process_ingress_dns_query(XfwDnsCtx *dns_ctx, const XfwDnsHdr *dh)
 	 * except for IXFR queries.
 	 */
 	if (unlikely(dh->ancount != 0))
-		return XFW_MAKE_CTX_DROP_EXT(dns_ctx, XFW_DNS_ANS_OR_AUTHS_IN_QUERY,
-					     ": ancount = %u",
-					     bpf_ntohs(dh->ancount));
+		return XFW_MAKE_DROP_EXT(&key->src_addr, dns_ctx->pkt_sz,
+					 XFW_DNS_ANS_OR_AUTHS_IN_QUERY,
+					 ": ancount = %u",
+					 bpf_ntohs(dh->ancount));
 
 	/*
 	 * Maximum two records allowed (exactly in this order):
 	 * EDNS OPT RR, TSIG RR.
 	 */
 	if (bpf_ntohs(dh->arcount) > 2)
-		return XFW_MAKE_CTX_DROP_EXT(dns_ctx, XFW_DNS_QRY_BAD_ARCOUNT,
-					     ": %u", bpf_ntohs(dh->arcount));
+		return XFW_MAKE_DROP_EXT(&key->src_addr, dns_ctx->pkt_sz,
+					 XFW_DNS_QRY_BAD_ARCOUNT,
+					 ": %u", bpf_ntohs(dh->arcount));
 
 	return XFW_CTX_CONTINUE;
 }
@@ -301,42 +307,54 @@ parse_full_dns_rr(XfwMd *ctx, XfwHdrCursor* hdr_cur)
 }
 
 static __always_inline int
-process_ingress_dns_response(XfwDnsCtx *dns_ctx, const XfwDnsHdr *dh)
+process_ingress_dns_response(XfwDnsCtx *dns_ctx, const XfwTcpConnKey *key,
+			     const XfwDnsHdr *dh)
 {
 	/*
 	 * Drop all ingress responses, which we didn't see an
 	 * outgoing queries for.
 	 */
-	if (bpf_map_lookup_elem(&MAP_DNS_EGR_FD_REF, &dh->id) == NULL)
-		return XFW_MAKE_CTX_DROP(dns_ctx, XFW_DNS_NOT_ASKED_RESPONSE);
+	if (!bpf_map_lookup_elem(&MAP_DNS_EGR_FD_REF, &dh->id))
+		return XFW_MAKE_DROP(&key->src_addr, dns_ctx->pkt_sz,
+				     XFW_DNS_NOT_ASKED_RESPONSE);
 
 
 	if (unlikely(dns_ctx->pkt_sz > MAX_DNS_UDP_PACKET))
-		return XFW_MAKE_CTX_DROP_EXT(dns_ctx, XFW_DNS_LARGE_RESPONSE,
-					     ": %u", dns_ctx->pkt_sz);
+		return XFW_MAKE_DROP_EXT(&key->src_addr, dns_ctx->pkt_sz,
+					 XFW_DNS_LARGE_RESPONSE,
+					 ": %u", dns_ctx->pkt_sz);
 
 	/* We don't support multiple DNS queries - it's quite rare case */
 	if (dh->qdcount != bpf_htons(1))
-		return XFW_MAKE_CTX_DROP(dns_ctx, XFW_DNS_MULTIPLE_QUESTIONS);
+		return XFW_MAKE_DROP(&key->src_addr, dns_ctx->pkt_sz,
+				     XFW_DNS_MULTIPLE_QUESTIONS);
 
-	if (parse_single_dns_question(dns_ctx->ctx, &dns_ctx->hdr_cur, dh) == NULL)
-		return XFW_MAKE_CTX_DROP(dns_ctx, XFW_DNS_BAD_QUESTION);
+	if (!parse_single_dns_question(dns_ctx->ctx,
+				       &dns_ctx->hdr_cur, dh))
+		return XFW_MAKE_DROP(&key->src_addr, dns_ctx->pkt_sz,
+				     XFW_DNS_BAD_QUESTION);
 
 	uint16_t an_count = bpf_ntohs(dh->ancount);
 
 	if (an_count > MAX_ANCOUNT)
-		return XFW_MAKE_CTX_DROP_EXT(dns_ctx, XFW_DNS_RESP_ANS_OVERLIMIT,
-					     ": %u", an_count);
+		return XFW_MAKE_DROP_EXT(&key->src_addr, dns_ctx->pkt_sz,
+					 XFW_DNS_RESP_ANS_OVERLIMIT,
+					 ": %u", an_count);
 
 	uint16_t i;
 	bpf_for (i, 0, an_count) {
-		XfwDnsRR *dr = parse_full_dns_rr(dns_ctx->ctx, &dns_ctx->hdr_cur);
+		XfwDnsRR *dr =
+			parse_full_dns_rr(dns_ctx->ctx, &dns_ctx->hdr_cur);
 		if (dr == NULL)
-			return XFW_MAKE_CTX_DROP(dns_ctx, XFW_DNS_BAD_RR);
+			return XFW_MAKE_DROP(&key->src_addr,
+					     dns_ctx->pkt_sz,
+					     XFW_DNS_BAD_RR);
 
 		if (dr->ttl == 0 || bpf_ntohl(dr->ttl) > 604800)
-			return XFW_MAKE_CTX_DROP_EXT(dns_ctx, XFW_DNS_ANSWER_ANOMALY,
-						     ": %lu", bpf_ntohl(dr->ttl));
+			return XFW_MAKE_DROP_EXT(&key->src_addr,
+						 dns_ctx->pkt_sz,
+						 XFW_DNS_ANSWER_ANOMALY,
+						 ": %lu", bpf_ntohl(dr->ttl));
 	}
 
 	return XFW_CTX_CONTINUE;
@@ -360,33 +378,20 @@ init_dns_ctx(XfwDnsCtx *dns_ctx, XfwMd *ctx, XfwPerCpuStats *global_stats)
 
 	if (unlikely(md->ip_pos > L3_L4_HDRS_MAXLEN))
 		return -1;
-	void *ip_hdr = (void *)(long)ctx->data + md->ip_pos;
-	if (md->is_ipv4) {
-		struct iphdr *ipv4 = ip_hdr;
-		if (unlikely((void*)(ipv4 + 1) > dns_ctx->hdr_cur.end))
-			return -1;
-		xfw_ipv4_to_ipv6_mapped(ipv4->saddr, dns_ctx->ilog_addr.addr32);
-	}
-	else {
-		struct ipv6hdr *ipv6 = ip_hdr;
-		if (unlikely((void*)(ipv6 + 1) > dns_ctx->hdr_cur.end))
-			return -1;
-		dns_ctx->ilog_addr.in6 = ipv6->saddr;
-	}
-
 	dns_ctx->pkt_sz = XFW_CTX_MD(ctx)->data_end - XFW_CTX_MD(ctx)->data;
 
 	return 0;
 }
 
 int __noinline
-ingress_dns_filter_global(XfwMd *ctx, XfwPerCpuStats *global_stats)
+ingress_dns_filter_global(XfwMd *ctx, const XfwTcpConnKey *key,
+			 XfwPerCpuStats *global_stats)
 {
 	/*
 	 * Internal error that can't be reported. However it is impossible due
 	 * to check in ingress_dns_filter. This is just check for verifier.
 	 */
-	if (unlikely(!global_stats))
+	if (unlikely(!global_stats || !key))
 		return XFW_CTX_CONTINUE;
 
 	XfwDnsCtx dns_ctx;
@@ -397,20 +402,21 @@ ingress_dns_filter_global(XfwMd *ctx, XfwPerCpuStats *global_stats)
 
 	XfwDnsHdr *dh = parse_dnshdr(&dns_ctx.hdr_cur);
 	if (unlikely(dh == NULL))
-		return XFW_MAKE_CTX_DROP(&dns_ctx, XFW_DNS_BADHDR_INGRESS);
+		return XFW_MAKE_DROP(&key->src_addr, dns_ctx.pkt_sz,
+				     XFW_DNS_BADHDR_INGRESS);
 
 	uint16_t hflags = bpf_ntohs(dh->flags);
 	uint8_t qr = (hflags >> 15) & 1;
 
 	if (qr == DNS_QUERY) /* Is query */
-		return process_ingress_dns_query(&dns_ctx, dh);
+		return process_ingress_dns_query(&dns_ctx, key, dh);
 
 	/* Packet is response */
-	return process_ingress_dns_response(&dns_ctx, dh);
+	return process_ingress_dns_response(&dns_ctx, key, dh);
 }
 
 static __always_inline int
-ingress_dns_filter(XfwGlobalCtx *ctx)
+ingress_dns_filter(XfwGlobalCtx *ctx, const XfwTcpConnKey *key)
 {
 	if (unlikely(!ctx->cfg->rules.dns.enabled))
 		return XFW_CTX_CONTINUE;
@@ -450,7 +456,7 @@ ingress_dns_filter(XfwGlobalCtx *ctx)
 		return XFW_CTX_CONTINUE;
 	}
 
-	return ingress_dns_filter_global(ctx->ctx, ctx->g_stats);
+	return ingress_dns_filter_global(ctx->ctx, key, ctx->g_stats);
 }
 
 static __always_inline void

--- a/bpf/dst.h
+++ b/bpf/dst.h
@@ -71,7 +71,7 @@ populate_dst_info(const XfwGlobalCtx *ctx, XfwDstKey *key, __u8 *default_idx)
 }
 
 static __always_inline int
-xfw_dst_filter(const XfwGlobalCtx *ctx)
+xfw_dst_filter(const XfwGlobalCtx *ctx, const XfwTcpConnKey *key)
 {
 	XfwDstKey dst_key;
 	uint8_t dst_default;
@@ -84,9 +84,10 @@ xfw_dst_filter(const XfwGlobalCtx *ctx)
 	if (!rule) {
 		XfwActionRule *default_rule = &ctx->cfg->rules.defaults[dst_default];
 		if (default_rule->action == XFW_ACTION_BLOCK)
-			return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_DST_BLOCKED, ": %pI6",
-						     &dst_key.addr.in6,
-						     "(by default action)");
+			return XFW_MAKE_DROP_EXT(&key->src_addr, ctx->pkt_sz,
+						 XFW_DST_BLOCKED, ": %pI6",
+						 &dst_key.addr.in6,
+						 "(by default action)");
 		if (default_rule->action == XFW_ACTION_ALLOW)
 			return XFW_CTX_CONTINUE;
 
@@ -94,14 +95,16 @@ xfw_dst_filter(const XfwGlobalCtx *ctx)
 		if (xfw_is_allowed_by_rlimits(ctx, &default_rule->rlimit))
 			return XFW_CTX_CONTINUE;
 
-		return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_DST_RATE_LIMITED,
-					     ": %pI6", &dst_key.addr.in6,
-					     "(by default action)");
+		return XFW_MAKE_DROP_EXT(&key->src_addr, ctx->pkt_sz,
+					 XFW_DST_RATE_LIMITED,
+					 ": %pI6", &dst_key.addr.in6,
+					 "(by default action)");
 	}
 
 	if (rule->action == XFW_ACTION_BLOCK)
-		return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_DST_BLOCKED, ": %pI6",
-					     &dst_key.addr.in6);
+		return XFW_MAKE_DROP_EXT(&key->src_addr, ctx->pkt_sz,
+					 XFW_DST_BLOCKED, ": %pI6",
+					 &dst_key.addr.in6);
 
 	if (rule->action == XFW_ACTION_ALLOW)
 		return XFW_CTX_CONTINUE;
@@ -110,8 +113,9 @@ xfw_dst_filter(const XfwGlobalCtx *ctx)
 	if (xfw_is_allowed_by_rlimits(ctx, &rule->rlimit))
 		return XFW_CTX_CONTINUE;
 
-	return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_DST_RATE_LIMITED, ": %pI6",
-				     &dst_key.addr.in6);
+	return XFW_MAKE_DROP_EXT(&key->src_addr, ctx->pkt_sz,
+				 XFW_DST_RATE_LIMITED, ": %pI6",
+				 &dst_key.addr.in6);
 }
 
 #undef BANNER

--- a/bpf/filter.h
+++ b/bpf/filter.h
@@ -35,6 +35,25 @@
 #endif
 
 /*
+ * TCP connection tracking key.
+ *
+ * The full TCP 4-tuple is used to uniquely identify a connection and keep
+ * connections sharing the same endpoint in separate authentication states.
+ *
+ * The key is always normalized to the client-to-server direction regardless
+ * of the packet direction. For ingress traffic, source and destination are
+ * used as-is. For egress traffic, they are reversed so that packets in both
+ * directions of the same connection resolve to the same map entry.
+ */
+typedef struct XfwTcpConnKey {
+	XfwIp		src_addr; /* IPv4 uses the low 32 bits; the rest stays zero. */
+	XfwIp		dst_addr;
+	XfwPort		src_port;
+	XfwPort		dst_port;
+} XfwTcpConnKey;
+STATIC_ASSERT(sizeof(XfwTcpConnKey) == 36, "Invalid XfwTcpConnKey size");
+
+/*
  * Read-only for eBPF.
  * Keys are taken from XfwRLimitRule.bucket_idx.
  */
@@ -103,16 +122,16 @@ count_tx_stat(const XfwGlobalCtx *ctx, enum XfwTxStat reason)
  * Avoid returning DROP codes directly without using these 2 functions, as it is
  * easy to forget updating the dropped packet statistics.
  */
-#define XFW_MAKE_CTX_DROP_EXT(ctx, reason_idx, postfix, args...)	\
+#define XFW_MAKE_DROP_EXT(ilog_addr, pkt_sz, reason_idx, postfix, args...) \
 ({									\
-	REGISTER_INCIDENT(ctx, reason_idx);				\
+	register_incident(ilog_addr, pkt_sz, reason_idx);		\
 	XFW_CTX_DBG("[DROP] %s" postfix,				\
 		    xfw_drop_stats[reason_idx].desc, ##args);	\
 	XFW_CTX_DROP;							\
 })
 
-#define XFW_MAKE_CTX_DROP(ctx, reason_idx, args...)			\
-	XFW_MAKE_CTX_DROP_EXT(ctx, reason_idx, "", ##args)
+#define XFW_MAKE_DROP(ilog_addr, pkt_sz, reason_idx, args...)		\
+	XFW_MAKE_DROP_EXT(ilog_addr, pkt_sz, reason_idx, "", ##args)
 
 /**
  * Avoid returning PASS codes directly without using these 2 functions, as it is

--- a/bpf/incident_log.h
+++ b/bpf/incident_log.h
@@ -181,6 +181,3 @@ register_incident(const XfwIp* ilog_addr, uint32_t pkt_sz, enum XfwDropStat reas
 	else 
 		update_drop_cnt();
 }
-
-#define REGISTER_INCIDENT(ctx, reason)					\
-	register_incident(&(ctx)->ilog_addr, (ctx)->pkt_sz, reason)

--- a/bpf/tc.c
+++ b/bpf/tc.c
@@ -38,7 +38,8 @@ SHADOW_MAP(MAP_NET_IP6_BASENAME, BPF_MAP_TYPE_LPM_TRIE, XFW_MAX_PROTECTED_NET_RU
  * Parsing function, should not drop packets!
  */
 static __always_inline int
-out_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey* prot_net_key, void **prot_net_map)
+out_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey* prot_net_key, void **prot_net_map,
+	       XfwTcpConnKey *key)
 {
 	switch (ctx->ipver) {
 	case bpf_ntohs(ETH_P_IP): {
@@ -48,7 +49,8 @@ out_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey* prot_net_key, void **prot_net_map
 			return XFW_MAKE_CTX_PASS(ctx, XFW_IP4_BADHDR_EGRESS);
 
 		ctx->l4_proto = (u8)proto;
-		xfw_ipv4_to_ipv6_mapped(ctx->iph4->daddr, ctx->ilog_addr.addr32);
+		xfw_ipv4_to_ipv6_mapped(ctx->iph4->daddr, key->src_addr.addr32);
+		xfw_ipv4_to_ipv6_mapped(ctx->iph4->saddr, key->dst_addr.addr32);
 		ipv4_populate_lpm_key(ctx->iph4->daddr, &prot_net_key->addr4);
 		*prot_net_map = SELECT_SHADOW_MAP(MAP_NET_IP4_BASENAME,
 						   ctx->cfg->amap_prot_net);
@@ -62,7 +64,8 @@ out_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey* prot_net_key, void **prot_net_map
 			return XFW_MAKE_CTX_PASS(ctx, XFW_IP6_BADHDR_EGRESS);
 
 		ctx->l4_proto = (u8)proto;
-		ctx->ilog_addr.in6 = ctx->iph6->daddr;
+		key->src_addr.in6 = ctx->iph6->daddr;
+		key->dst_addr.in6 = ctx->iph6->saddr;
 		ipv6_populate_lpm_key(&ctx->iph6->daddr, &prot_net_key->addr6);
 		*prot_net_map = SELECT_SHADOW_MAP(MAP_NET_IP6_BASENAME,
 						   ctx->cfg->amap_prot_net);
@@ -80,7 +83,7 @@ out_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey* prot_net_key, void **prot_net_map
  * Parsing function, should not drop packets!
  */
 static __always_inline int
-out_process_l4(XfwGlobalCtx *ctx)
+out_process_l4(XfwGlobalCtx *ctx, XfwTcpConnKey *key)
 {
 	switch (ctx->l4_proto) {
 	case XFW_L4_PROTO_TCP: {
@@ -88,6 +91,8 @@ out_process_l4(XfwGlobalCtx *ctx)
 		if (unlikely(parse_tcphdr(&ctx->hdr_cur, &ctx->th) <= 0))
 			return XFW_MAKE_CTX_PASS(ctx, XFW_TCP_BADHDR_EGRESS);
 
+		key->src_port = ctx->th->dest;
+		key->dst_port = ctx->th->source;
 		/* It is a regular case, don't need to add any statistic */
 		return XFW_CTX_CONTINUE;
 	}
@@ -109,10 +114,10 @@ out_process_l4(XfwGlobalCtx *ctx)
 }
 
 static __always_inline int
-process_downstream_egress(const XfwGlobalCtx *ctx)
+process_downstream_egress(const XfwGlobalCtx *ctx, const XfwTcpConnKey *key)
 {
 	/* Traffic still heading toward protected services must pass dst policy. */
-	CHAIN(xfw_dst_filter, ctx);
+	CHAIN(xfw_dst_filter, ctx, key);
 
 	return XFW_CTX_CONTINUE;
 }
@@ -154,21 +159,22 @@ xfw_tc_egress_filter(struct XfwGlobalCtx *ctx, bool *is_upstream_egress)
 		return XFW_MAKE_CTX_PASS(ctx, XFW_ETH_BADHDR_EGRESS);
 	ctx->ipver = ipver;
 
+	XfwTcpConnKey key;
 	/* Build map lookup keys before policy evaluation. */
-	CHAIN(out_process_l3, ctx, &prot_net_key, &prot_net_map);
-	CHAIN(out_process_l4, ctx);
+	CHAIN(out_process_l3, ctx, &prot_net_key, &prot_net_map, &key);
+	CHAIN(out_process_l4, ctx, &key);
 	/* Parsing is complete; start policy checks. */
 
 	*is_upstream_egress = (bpf_map_lookup_elem(prot_net_map, &prot_net_key) == NULL);
 	if (!*is_upstream_egress) /* Packets going to upstream. */
-		CHAIN(process_downstream_egress, ctx);
+		CHAIN(process_downstream_egress, ctx, &key);
 	
 	/* 
 	 * Still needs to be called when rules are not loaded. TCP AUTH filter is
 	 * atomatically inactive at that time.
 	 */
 	if (ctx->l4_proto == XFW_L4_PROTO_TCP)
-		tcp_auth_conn_egress_learning(ctx);
+		tcp_auth_conn_egress_learning(ctx, &key);
 
 	return XFW_CTX_PASS;
 }

--- a/bpf/tcp_anomaly_filter.h
+++ b/bpf/tcp_anomaly_filter.h
@@ -16,18 +16,20 @@
 #include "parsing_helpers.h"
 
 static __always_inline int
-tcp_anomaly_filter(const XfwGlobalCtx *ctx)
+tcp_anomaly_filter(const XfwGlobalCtx *ctx, const XfwTcpConnKey *key)
 {
 	if (!ctx->cfg->rules.tcp_anomaly.enabled)
 		return XFW_CTX_CONTINUE;
 
 	/* Take correct 8-bit TCP flags from words[3] */
-	const uint8_t tcp_flags = (uint8_t)((tcp_flag_word(ctx->th) >> 8) & 0xFF);
+	const uint8_t tcp_flags =
+		(uint8_t)((tcp_flag_word(ctx->th) >> 8) & 0xFF);
 	bool r = bpf_bitset64_test(ctx->cfg->rules.tcp_anomaly.bad_flags.data,
 				   tcp_flags);
 	if (unlikely(r))
-		return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_TCP_ANOM_BAD_FLAGS,
-					     ": flag_word=%u", tcp_flags);
+		return XFW_MAKE_DROP_EXT(&key->src_addr, ctx->pkt_sz,
+					 XFW_TCP_ANOM_BAD_FLAGS,
+					 ": flag_word=%u", tcp_flags);
 
 	/*
 	 * TCP port 0 is reserved and MUST NOT be used for normal communication.
@@ -40,22 +42,26 @@ tcp_anomaly_filter(const XfwGlobalCtx *ctx)
 	 *    1024, etc."
 	 */
 	if (unlikely(ctx->th->source == 0 || ctx->th->dest == 0))
-		return XFW_MAKE_CTX_DROP(ctx, XFW_TCP_ANOM_ZERO_PORT);
+		return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+				     XFW_TCP_ANOM_ZERO_PORT);
 
 	if (!ctx->th->syn)
 		return XFW_CTX_CONTINUE;
 
 	if (unlikely(ctx->cfg->rules.tcp_anomaly.syn_without_opt_enabled
 		     && ctx->th->doff <= 5))
-		return XFW_MAKE_CTX_DROP(ctx, XFW_TCP_ANOM_SYN_NO_OPTIONS);
+		return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+				     XFW_TCP_ANOM_SYN_NO_OPTIONS);
 
 	if (unlikely(ctx->cfg->rules.tcp_anomaly.syn_with_payload_enabled
 		     && (void *)ctx->th + ctx->th->doff * 4 < ctx->hdr_cur.end))
-		return XFW_MAKE_CTX_DROP(ctx, XFW_TCP_ANOM_SYN_HAS_DATA);
+		return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+				     XFW_TCP_ANOM_SYN_HAS_DATA);
 
 	if (unlikely(ctx->cfg->rules.tcp_anomaly.syn_seqno_enabled
 		     && ctx->th->seq == ctx->cfg->rules.tcp_anomaly.syn_seqno_value))
-		return XFW_MAKE_CTX_DROP(ctx, XFW_TCP_ANOM_SYN_BAD_SEQ);
+		return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+				     XFW_TCP_ANOM_SYN_BAD_SEQ);
 
 	return XFW_CTX_CONTINUE;
 }

--- a/bpf/tcp_auth.h
+++ b/bpf/tcp_auth.h
@@ -4,11 +4,12 @@
  * SPDX-FileCopyrightText: © 2026 Tempesta Technologies, Inc.
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
- * The filter blocks ACK and RST floods for TCP flows, which it didn't observe
- * SYN packets for (authenticated flows).
+ * The filter blocks unsolicited TCP traffic, such as ACK and RST floods, for
+ * connections that are not present in the authenticated connection map.
  *
  * Logic:
- *   - Maintain per-connection state in a shared LRU hash map.
+ *   - Maintain per-connection state in a shared LRU hash map keyed by the
+ *     normalized TCP 4-tuple.
  *   - Provide ingress filtering based on connection state.
  *   - Handle egress connection tracking, including SYN-based trust.
  *   - Manage FIN/RST events and connection expiration.
@@ -48,19 +49,12 @@
 
 #include "filter.h"
 
-typedef struct XfwSockAddr {
-	XfwIp		addr; /* IPv4 uses the low 32 bits; the rest stays zero. */
-	XfwPort		port;
-	uint8_t		__reserved[2];
-} XfwSockAddr;
-STATIC_ASSERT(sizeof(XfwSockAddr) == 20, "Invalid XfwSockAddr size");
-
 /*
  * For TCP Authentication Filter there are only 2 states for a connection:
  * unauthenticated (no XfwTcpConnState entry in the map) and authenticated
  * (a map entry exists).
  *
- * @last_fin_time	- timestamp in seconds for the last seen FIN
+ * @last_fin_time_jiff	- timestamp in jiffies of the last observed FIN
  */
 typedef struct XfwTcpConnState {
 	uint64_t		last_fin_time_jiff; /* In jiffies */
@@ -68,7 +62,7 @@ typedef struct XfwTcpConnState {
 
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
-	__type(key, XfwSockAddr);
+	__type(key, XfwTcpConnKey);
 	__type(value, XfwTcpConnState);
 	/* Pinned so ingress and egress programs share authenticated sockets. */
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
@@ -87,26 +81,26 @@ struct {
 	(UINT64_MAX - TCP_AUTH_CONN_CLOSE_TIMEOUT_JIFF) /* Keep timeout math bounded. */
 
 static __always_inline XfwTcpConnState *
-tcp_auth_conn_lookup(const XfwSockAddr *addr)
+tcp_auth_conn_lookup(const XfwTcpConnKey *key)
 {
-	return bpf_map_lookup_elem(&MAP_TCP_CONN_REF, addr);
+	return bpf_map_lookup_elem(&MAP_TCP_CONN_REF, key);
 }
 
 static __always_inline void
-tcp_auth_conn_delete(const XfwSockAddr *addr)
+tcp_auth_conn_delete(const XfwTcpConnKey *key)
 {
-	bpf_map_delete_elem(&MAP_TCP_CONN_REF, addr);
+	bpf_map_delete_elem(&MAP_TCP_CONN_REF, key);
 	XFW_CTX_DBG("Delete TCP AUTH connection");
 }
 
 static __always_inline void
-tcp_auth_conn_add(const XfwSockAddr *addr)
+tcp_auth_conn_add(const XfwTcpConnKey *key)
 {
 	XfwTcpConnState new_conn = {
 		.last_fin_time_jiff = TCP_AUTH_CONN_MAX_FIN_TIME_JIFF
 	};
 
-	bpf_map_update_elem(&MAP_TCP_CONN_REF, addr, &new_conn, BPF_ANY);
+	bpf_map_update_elem(&MAP_TCP_CONN_REF, key, &new_conn, BPF_ANY);
 	XFW_CTX_DBG("Add TCP AUTH connection");
 }
 
@@ -125,9 +119,9 @@ tcp_auth_is_conn_outdated(const XfwGlobalCtx *ctx, const XfwTcpConnState *conn)
 }
 
 static __always_inline bool
-tcp_auth_has_conn_trusted(const XfwGlobalCtx *ctx, const XfwSockAddr *addr)
+tcp_auth_has_conn_trusted(const XfwGlobalCtx *ctx, const XfwTcpConnKey *key)
 {
-	XfwTcpConnState *conn = tcp_auth_conn_lookup(addr);
+	XfwTcpConnState *conn = tcp_auth_conn_lookup(key);
 
 	if (!conn || tcp_auth_is_conn_outdated(ctx, conn))
 		return false;
@@ -160,19 +154,21 @@ enum XfwTcpAuthEvent {
  * keeping the per-packet cost minimal.
  */
 static __always_inline int
-tcp_auth_conn_ingress_filter(const XfwGlobalCtx *ctx, const XfwSockAddr *addr,
+tcp_auth_conn_ingress_filter(const XfwGlobalCtx *ctx, const XfwTcpConnKey *key,
 			     enum XfwTcpAuthEvent ev)
 {
 	if (unlikely(!ctx->cfg->rules.tcp_auth.enabled))
 		return XFW_CTX_CONTINUE;
 
-	XfwTcpConnState *conn = tcp_auth_conn_lookup(addr);
+	XfwTcpConnState *conn = tcp_auth_conn_lookup(key);
 	if (likely(!(conn))) /* Fast path for unauthenticated flood traffic. */
-		return XFW_MAKE_CTX_DROP(ctx, XFW_TCP_AUTH_FAILED);
+		return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+				     XFW_TCP_AUTH_FAILED);
 
 	if (unlikely(tcp_auth_is_conn_outdated(ctx, (conn)))) {
-		tcp_auth_conn_delete(addr);
-		return XFW_MAKE_CTX_DROP(ctx, XFW_TCP_AUTH_TIMEOUT);
+		tcp_auth_conn_delete(key);
+		return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+				     XFW_TCP_AUTH_TIMEOUT);
 	}
 
 	switch (ev) {
@@ -181,7 +177,7 @@ tcp_auth_conn_ingress_filter(const XfwGlobalCtx *ctx, const XfwSockAddr *addr,
 		 * Out-of-order traffic: early RST clears the connection,
 		 * mirroring TCP stack behavior.
 		 */
-		tcp_auth_conn_delete(addr);
+		tcp_auth_conn_delete(key);
 		return XFW_CTX_CONTINUE;
 
 	case TCP_AUTH_EVENT_FIN:
@@ -195,23 +191,18 @@ tcp_auth_conn_ingress_filter(const XfwGlobalCtx *ctx, const XfwSockAddr *addr,
 }
 
 static __always_inline void
-tcp_auth_conn_egress_learning(const XfwGlobalCtx *ctx)
+tcp_auth_conn_egress_learning(const XfwGlobalCtx *ctx, const XfwTcpConnKey *key)
 {
 	struct tcphdr *th = ctx->th;
 	VERIFY_TRUE_OR_RETURN((void *)(th + 1) <= ctx->hdr_cur.end, (void)0);
 
-	const XfwSockAddr addr = {
-		.addr = ctx->ilog_addr,
-		.port = th->dest
-	};
-	
 	if (unlikely(th->rst)) {
 		/* An early RST can safely remove a learned tuple. */
-		tcp_auth_conn_delete(&addr);
+		tcp_auth_conn_delete(key);
 		return;
 	}
 
-	XfwTcpConnState *conn = tcp_auth_conn_lookup(&addr);
+	XfwTcpConnState *conn = tcp_auth_conn_lookup(key);
 
 	/*
 	 * Trusted connection tracking in tc.c has two modes:
@@ -237,7 +228,7 @@ tcp_auth_conn_egress_learning(const XfwGlobalCtx *ctx)
 	 */
 	if (!conn) {
 		if (unlikely(!ctx->cfg->rules.tcp_auth.enabled || th->syn))
-			tcp_auth_conn_add(&addr);
+			tcp_auth_conn_add(key);
 		return;
 	}
 

--- a/bpf/tcp_syncookies.h
+++ b/bpf/tcp_syncookies.h
@@ -609,7 +609,7 @@ tcp_sk_listen_lookup(const XfwGlobalCtx *ctx)
  * are tolerated where possible.
  */
 static __always_inline int
-tcp_syncookies_syn_filter(XfwGlobalCtx *ctx)
+tcp_syncookies_syn_filter(XfwGlobalCtx *ctx, const XfwTcpConnKey *key)
 {
 	XfwTcpSynCookieTs *ts = __tcp_get_tcp_syncookie_ts();
 	XFW_ASSERT(ts);
@@ -638,8 +638,9 @@ tcp_syncookies_syn_filter(XfwGlobalCtx *ctx)
 	if (unlikely(!sk)) {
 		/* Treat a SYN for a non-listening or absent socket as flooding. */
 		ts->last_gen_jiff = ctx->ts_jiff;
-		return XFW_MAKE_CTX_DROP(ctx, XFW_SYNCOOKIE_FAILED,
-					 "No listening socket");
+		return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+				     XFW_SYNCOOKIE_FAILED,
+				     "No listening socket");
 	}
 
 	int64_t seq_mss = bpf_tcp_gen_syncookie(sk, ctx->iph, iph_len, ctx->th,
@@ -660,22 +661,25 @@ tcp_syncookies_syn_filter(XfwGlobalCtx *ctx)
 
 	if (unlikely(seq_mss < 0)) {
 		XFW_CTX_DBG("Cannot generate syncookie, %d", seq_mss);
-		return XFW_MAKE_CTX_DROP(ctx, XFW_SYNCOOKIE_FAILED, "bad MSS");
+		return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+				     XFW_SYNCOOKIE_FAILED, "bad MSS");
 	}
 
 	XfwTCPOpts opts = { 0 };
 	long r = tcp_parse_opts(ctx, &opts);
 	if (unlikely(r)) {
 		XFW_CTX_DBG("Cannot parse TCP options, %d", r);
-		return XFW_MAKE_CTX_DROP(ctx, XFW_SYNCOOKIE_FAILED,
-					 "bad TCP options in SYN");
+		return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+				     XFW_SYNCOOKIE_FAILED,
+				     "bad TCP options in SYN");
 	}
 
 	r = tcp_syncookies_make_synack(ctx, (uint32_t)seq_mss,
 				       (uint16_t)(seq_mss >> 32), &opts);
 	if (unlikely(r))
-		return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_SYNCOOKIE_FAILED,
-					     "Cannot generate SYN-ACK, %d", r);
+		return XFW_MAKE_DROP_EXT(&key->src_addr, ctx->pkt_sz,
+					 XFW_SYNCOOKIE_FAILED,
+					 "Cannot generate SYN-ACK, %d", r);
 
 	return MAKE_XDP_TX(ctx, XFW_SYNCOOKIE_GENERATED);
 }
@@ -688,13 +692,14 @@ tcp_syncookies_syn_filter(XfwGlobalCtx *ctx)
  *  - DROP if SYN cookie is invalid or host socket not found
  */
 static __always_inline int
-tcp_syncookies_ack_filter(const XfwGlobalCtx *ctx)
+tcp_syncookies_ack_filter(const XfwGlobalCtx *ctx, const XfwTcpConnKey *key)
 {
 	/* Lookup socket to validate ACK against SYN cookie */
 	struct bpf_sock *sk = tcp_sk_listen_lookup(ctx);
 	if (!sk)
-		return XFW_MAKE_CTX_DROP(ctx, XFW_SYNCOOKIE_FAILED,
-					 "No host socket");
+		return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+				     XFW_SYNCOOKIE_FAILED,
+				     "No host socket");
 
 	const bool in_listen_state = sk->state == BPF_TCP_LISTEN;
 	bpf_sk_release(sk);
@@ -718,8 +723,10 @@ tcp_syncookies_ack_filter(const XfwGlobalCtx *ctx)
 	if (ctx->ipver == bpf_ntohs(ETH_P_IP)) {
 		int r = bpf_tcp_raw_check_syncookie_ipv4(ctx->iph4, ctx->th);
 		if (r < 0)
-			return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_SYNCOOKIE_FAILED,
-				"IPv4 ACK with invalid cookie, retcode=%d.", r);
+			return XFW_MAKE_DROP_EXT(&key->src_addr, ctx->pkt_sz,
+						 XFW_SYNCOOKIE_FAILED,
+						 "IPv4 ACK with invalid cookie,"
+						 " retcode=%d.", r);
 	}
 	else if (ctx->ipver == bpf_ntohs(ETH_P_IPV6)) {
 		/* This check is just to satisfy the verifier. */
@@ -727,8 +734,10 @@ tcp_syncookies_ack_filter(const XfwGlobalCtx *ctx)
 
 		int r = bpf_tcp_raw_check_syncookie_ipv6(ctx->iph6, ctx->th);
 		if (r < 0)
-			return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_SYNCOOKIE_FAILED,
-				"IPv6 ACK with invalid cookie, retcode=%d.", r);
+			return XFW_MAKE_DROP_EXT(&key->src_addr, ctx->pkt_sz,
+						 XFW_SYNCOOKIE_FAILED,
+						 "IPv6 ACK with invalid cookie,"
+						 " retcode=%d.", r);
 	}
 
 	return XFW_CTX_CONTINUE;

--- a/bpf/xdp.c
+++ b/bpf/xdp.c
@@ -122,19 +122,21 @@ icmp_default_by_proto(uint8_t l4_proto)
 }
 
 static __always_inline int
-icmp_filter(const XfwGlobalCtx *ctx, const XfwIcmpKey *key)
+icmp_filter(const XfwGlobalCtx *ctx, const XfwTcpConnKey *key,
+	    const XfwIcmpKey *icmp_key)
 {
 	XfwActionRule *rule;
 
 	rule = bpf_map_lookup_elem(
-		SELECT_SHADOW_MAP(MAP_ICMP_BASENAME, ctx->cfg->amap_icmp), key);
+		SELECT_SHADOW_MAP(MAP_ICMP_BASENAME, ctx->cfg->amap_icmp), icmp_key);
 	if (!rule) {
-		uint8_t icmp_default = icmp_default_by_proto(key->proto);
+		uint8_t icmp_default = icmp_default_by_proto(icmp_key->proto);
 
 		XfwActionRule *default_rule = &ctx->cfg->rules.defaults[icmp_default];
 		switch (default_rule->action) {
 		case XFW_ACTION_BLOCK:
-			return XFW_MAKE_CTX_DROP(ctx, XFW_ICMP_DEFAULT_BLOCKED);
+			return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+					     XFW_ICMP_DEFAULT_BLOCKED);
 		case XFW_ACTION_ALLOW:
 			return XFW_CTX_CONTINUE;
 		default:
@@ -143,12 +145,14 @@ icmp_filter(const XfwGlobalCtx *ctx, const XfwIcmpKey *key)
 			if (xfw_is_allowed_by_rlimits(ctx, &default_rule->rlimit))
 				return XFW_CTX_CONTINUE;
 
-			return XFW_MAKE_CTX_DROP(ctx, XFW_ICMP_DEFAULT_RATE_LIMITED);
+			return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+					     XFW_ICMP_DEFAULT_RATE_LIMITED);
 		}
 	}
 
 	if (rule->action == XFW_ACTION_BLOCK)
-		return XFW_MAKE_CTX_DROP(ctx, XFW_ICMP_BLOCKED);
+		return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+				     XFW_ICMP_BLOCKED);
 
 	if (rule->action == XFW_ACTION_ALLOW)
 		return XFW_CTX_CONTINUE;
@@ -157,7 +161,8 @@ icmp_filter(const XfwGlobalCtx *ctx, const XfwIcmpKey *key)
 	if (xfw_is_allowed_by_rlimits(ctx, &rule->rlimit))
 		return XFW_CTX_CONTINUE;
 
-	return XFW_MAKE_CTX_DROP(ctx, XFW_ICMP_RATE_LIMITED);
+	return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+			     XFW_ICMP_RATE_LIMITED);
 }
 
 static __always_inline uint8_t
@@ -182,7 +187,8 @@ src_port_default_by_protos(uint16_t ipver, uint8_t l4_proto)
 }
 
 static __always_inline int
-src_filter_port(const XfwGlobalCtx *ctx, XfwPort port)
+src_filter_port(const XfwGlobalCtx *ctx, const XfwTcpConnKey *key,
+		XfwPort port)
 {
 	XfwSrcRule *rule;
 	if (ctx->l4_proto == XFW_L4_PROTO_UDP)
@@ -193,20 +199,24 @@ src_filter_port(const XfwGlobalCtx *ctx, XfwPort port)
 			SELECT_SHADOW_MAP(MAP_SRC_P_TCP_BASENAME, ctx->cfg->amap_src), &port);
 
 	if (!rule) {
-		uint8_t src_default = src_port_default_by_protos(ctx->ipver, ctx->l4_proto);
-		XfwActionRule *default_rule = &ctx->cfg->rules.defaults[src_default];
+		uint8_t src_default =
+			src_port_default_by_protos(ctx->ipver, ctx->l4_proto);
+		XfwActionRule *default_rule =
+			&ctx->cfg->rules.defaults[src_default];
 		switch (default_rule->action) {
 		case XFW_ACTION_BLOCK:
-			return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_SRC_PORT_DEFAULT_BLOCKED,
-						     ": %u", bpf_ntohs(port));
+			return XFW_MAKE_DROP_EXT(&key->src_addr, ctx->pkt_sz,
+						 XFW_SRC_PORT_DEFAULT_BLOCKED,
+						 ": %u", bpf_ntohs(port));
 		case XFW_ACTION_ALLOW:
 			return XFW_CTX_CONTINUE;
 		default:
 			/* XFW_ACTION_RATE_LIMIT */
 			XFW_ASSERT(default_rule->action == XFW_ACTION_RATE_LIMIT);
 
-			XfwRLimitSlidingWindow *b = XFW_MAP_LOOKUP_OR_INIT(
-				&MAP_SRC_PORT_RL_REF, &port, XfwRLimitSlidingWindow);
+			XfwRLimitSlidingWindow *b =
+				XFW_MAP_LOOKUP_OR_INIT(&MAP_SRC_PORT_RL_REF, &port,
+						       XfwRLimitSlidingWindow);
 			XFW_ASSERT(b);
 
 			const XfwRLimitIdx idx = default_rule->rlimit.named_idx;
@@ -215,13 +225,15 @@ src_filter_port(const XfwGlobalCtx *ctx, XfwPort port)
 			if (xfw_is_within_rlimit(ctx, &ctx->cfg->named_rates[idx], b))
 				return XFW_CTX_CONTINUE;
 
-			return XFW_MAKE_CTX_DROP(ctx, XFW_SRC_PORT_DEFAULT_RATE_LIMITED);
+			return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+					     XFW_SRC_PORT_DEFAULT_RATE_LIMITED);
 		}
 	}
 
 	if (rule->action == XFW_ACTION_BLOCK)
-		return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_SRC_PORT_BLOCKED,
-					     ": %u", bpf_ntohs(port));
+		return XFW_MAKE_DROP_EXT(&key->src_addr, ctx->pkt_sz,
+					 XFW_SRC_PORT_BLOCKED,
+					 ": %u", bpf_ntohs(port));
 
 	if (rule->action == XFW_ACTION_ALLOW)
 		return XFW_MAKE_CTX_PASS_EXT(ctx, XFW_SRC_PORT_ALLOWED,
@@ -236,8 +248,9 @@ src_filter_port(const XfwGlobalCtx *ctx, XfwPort port)
 	if (xfw_is_within_rlimit(ctx, &ctx->cfg->named_rates[rule->named_idx], b))
 		return XFW_CTX_CONTINUE;
 
-	return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_SRC_PORT_RATE_LIMITED,
-				     ": %u", bpf_ntohs(port));
+	return XFW_MAKE_DROP_EXT(&key->src_addr, ctx->pkt_sz,
+				 XFW_SRC_PORT_RATE_LIMITED,
+				 ": %u", bpf_ntohs(port));
 }
 
 static __always_inline void
@@ -287,7 +300,8 @@ populate_src_info(const XfwGlobalCtx *ctx, void **src_ip_map,
  * information) in addition to the IP address.
  */
 static __always_inline int
-src_filter_ip(const XfwGlobalCtx *ctx, XfwIpLpmKey *ip_lpm)
+src_filter_ip(const XfwGlobalCtx *ctx, const XfwTcpConnKey *key,
+	      XfwIpLpmKey *ip_lpm)
 {
 	uint8_t src_default;
 	void *src_ip_map;
@@ -298,19 +312,22 @@ src_filter_ip(const XfwGlobalCtx *ctx, XfwIpLpmKey *ip_lpm)
 	if (rule) {
 		switch (rule->action) {
 		case XFW_ACTION_BLOCK:
-			return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_SRC_IP_BLOCKED,
-						     ": %pI6", &ctx->ilog_addr.in6);
+			return XFW_MAKE_DROP_EXT(&key->src_addr, ctx->pkt_sz,
+						 XFW_SRC_IP_BLOCKED,
+						 ": %pI6",
+						 &key->src_addr.in6);
 
 		case XFW_ACTION_ALLOW:
 			return XFW_MAKE_CTX_PASS_EXT(ctx, XFW_SRC_IP_ALLOWED,
-						     ": %pI6", &ctx->ilog_addr.in6);
+						     ": %pI6",
+						     &key->src_addr.in6);
 		default:
 			/* XFW_ACTION_RATE_LIMIT */
 			XFW_ASSERT(rule->action == XFW_ACTION_RATE_LIMIT);
 
 			XfwRLimitSlidingWindow *b = XFW_MAP_LOOKUP_OR_INIT(
 							&MAP_SRC_RATELIM_REF,
-							&ctx->ilog_addr.in6,
+							&key->src_addr.in6,
 							XfwRLimitSlidingWindow);
 			XFW_ASSERT(b);
 
@@ -319,24 +336,27 @@ src_filter_ip(const XfwGlobalCtx *ctx, XfwIpLpmKey *ip_lpm)
 						 &ctx->cfg->named_rates[rule->named_idx],
 						 b))
 				return XFW_CTX_CONTINUE;
-			return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_SRC_IP_RATE_LIMITED,
-						     ": %pI6", &ctx->ilog_addr.in6);
+			return XFW_MAKE_DROP_EXT(&key->src_addr, ctx->pkt_sz,
+						 XFW_SRC_IP_RATE_LIMITED,
+						 ": %pI6", &key->src_addr.in6);
 		}
 	}
 
 	XfwActionRule *default_rule = &ctx->cfg->rules.defaults[src_default];
 	if (default_rule->action == XFW_ACTION_BLOCK)
-		return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_SRC_IP_DEFAULT_BLOCKED,
-					     ": %pI6", &ctx->ilog_addr.in6);
+		return XFW_MAKE_DROP_EXT(&key->src_addr, ctx->pkt_sz,
+					 XFW_SRC_IP_DEFAULT_BLOCKED,
+					 ": %pI6", &key->src_addr.in6);
 
 	if (default_rule->action == XFW_ACTION_ALLOW)
 		return XFW_CTX_CONTINUE;
 
 	XFW_ASSERT(default_rule->action == XFW_ACTION_RATE_LIMIT);
 
-	XfwRLimitSlidingWindow *b = XFW_MAP_LOOKUP_OR_INIT(&MAP_SRC_RATELIM_REF,
-						       &ctx->ilog_addr.in6,
-						       XfwRLimitSlidingWindow);
+	XfwRLimitSlidingWindow *b =
+		XFW_MAP_LOOKUP_OR_INIT(&MAP_SRC_RATELIM_REF,
+				       &key->src_addr.in6,
+				       XfwRLimitSlidingWindow);
 	XFW_ASSERT(b);
 
 	const XfwRLimitIdx idx = default_rule->rlimit.named_idx;
@@ -345,8 +365,9 @@ src_filter_ip(const XfwGlobalCtx *ctx, XfwIpLpmKey *ip_lpm)
 	if (xfw_is_within_rlimit(ctx, &ctx->cfg->named_rates[idx], b))
 		return XFW_CTX_CONTINUE;
 
-	return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_SRC_IP_DEFAULT_RATE_LIMITED,
-				     ": %pI6", &ctx->ilog_addr.in6);
+	return XFW_MAKE_DROP_EXT(&key->src_addr, ctx->pkt_sz,
+				 XFW_SRC_IP_DEFAULT_RATE_LIMITED,
+				 ": %pI6", &key->src_addr.in6);
 }
 
 /**
@@ -356,16 +377,17 @@ src_filter_ip(const XfwGlobalCtx *ctx, XfwIpLpmKey *ip_lpm)
  * We need to change the configuration to be able to split the layers.
  */
 static __always_inline int
-src_filter(const XfwGlobalCtx *ctx, XfwPort src_port, XfwIpLpmKey* src_ip_key)
+src_filter(const XfwGlobalCtx *ctx, const XfwTcpConnKey *key,
+	   XfwPort src_port, XfwIpLpmKey* src_ip_key)
 {
-	CHAIN(src_filter_ip, ctx, src_ip_key);
-	CHAIN(src_filter_port, ctx, src_port);
+	CHAIN(src_filter_ip, ctx, key, src_ip_key);
+	CHAIN(src_filter_port, ctx, key, src_port);
 
 	return XFW_CTX_CONTINUE;
 }
 
 static __always_inline int
-rst_rlimit(XfwGlobalCtx *ctx)
+rst_rlimit(XfwGlobalCtx *ctx, const XfwTcpConnKey *key)
 {
 	XfwActionRule *rule = &ctx->cfg->rules.tcp_flags[XFW_FLAGS_FILTER_RST];
 	if (rule->action != XFW_ACTION_RATE_LIMIT)
@@ -374,11 +396,12 @@ rst_rlimit(XfwGlobalCtx *ctx)
 	if (xfw_is_allowed_by_rlimits(ctx, &rule->rlimit))
 		return XFW_CTX_CONTINUE;
 
-	return XFW_MAKE_CTX_DROP(ctx, XFW_RST_RATE_LIMITED);
+	return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+			     XFW_RST_RATE_LIMITED);
 }
 
 static __always_inline int
-syn_rlimit(XfwGlobalCtx *ctx)
+syn_rlimit(XfwGlobalCtx *ctx, const XfwTcpConnKey *key)
 {
 	XfwActionRule *rule = &ctx->cfg->rules.tcp_flags[XFW_FLAGS_FILTER_SYN];
 	if (rule->action != XFW_ACTION_RATE_LIMIT)
@@ -388,25 +411,30 @@ syn_rlimit(XfwGlobalCtx *ctx)
 	if (xfw_is_allowed_by_rlimits(ctx, &rule->rlimit))
 		return XFW_CTX_CONTINUE;
 
-	return XFW_MAKE_CTX_DROP(ctx, XFW_SYN_RATE_LIMITED);
+	return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+			     XFW_SYN_RATE_LIMITED);
 }
 
 static __always_inline int
-in_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key)
+in_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key,
+	      XfwTcpConnKey *key)
 {
 	switch (ctx->ipver) {
 	case bpf_ntohs(ETH_P_IP): {
 		count_traffic_stat(ctx, XFW_IP4_TOTAL_INGRESS);
 		int proto = parse_iphdr(&ctx->hdr_cur, &ctx->iph4);
 		if (unlikely(proto < 0))
-			return XFW_MAKE_CTX_DROP(ctx, XFW_IP4_BADHDR_INGRESS);
+			return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+					     XFW_IP4_BADHDR_INGRESS);
 
 		/* Any MF bit or non-zero fragment offset means fragmented IPv4. */
 		if ((bpf_htons(ctx->iph4->frag_off) & 0x3fff) != 0)
-			return XFW_MAKE_CTX_DROP(ctx, XFW_IP4_FRAGMENTED_INGRESS);
+			return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+					     XFW_IP4_FRAGMENTED_INGRESS);
 
 		ctx->l4_proto = (u8)proto;
-		xfw_ipv4_to_ipv6_mapped(ctx->iph4->saddr, ctx->ilog_addr.addr32);
+		xfw_ipv4_to_ipv6_mapped(ctx->iph4->saddr, key->src_addr.addr32);
+		xfw_ipv4_to_ipv6_mapped(ctx->iph4->daddr, key->dst_addr.addr32);
 		ipv4_populate_lpm_key(ctx->iph4->saddr, &src_ip_key->addr4);
 		return XFW_CTX_CONTINUE;
 	}
@@ -415,12 +443,15 @@ in_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key)
 		int proto = parse_ip6hdr(&ctx->hdr_cur, &ctx->iph6);
 		if (unlikely(proto < 0)) {
 			if (proto == -EFBIG)
-				return XFW_MAKE_CTX_DROP(ctx, XFW_IP6_FRAGMENTED_INGRESS);
-			return XFW_MAKE_CTX_DROP(ctx, XFW_IP6_BADHDR_INGRESS);
+				return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+						     XFW_IP6_FRAGMENTED_INGRESS);
+			return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+					     XFW_IP6_BADHDR_INGRESS);
 		}
 
 		ctx->l4_proto = (u8)proto;
-		ctx->ilog_addr.in6 = ctx->iph6->saddr;
+		key->src_addr.in6 = ctx->iph6->saddr;
+		key->dst_addr.in6 = ctx->iph6->daddr;
 		ipv6_populate_lpm_key(&ctx->iph6->saddr, &src_ip_key->addr6);
 
 		return XFW_CTX_CONTINUE;
@@ -431,8 +462,9 @@ in_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key)
 	}
 	default : {
 		/* Unknown EtherTypes are not useful to the protected L3 services. */
-		return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_L2_UNKNOWN_INGRESS,
-					     ": %x", bpf_htons(ctx->ipver));
+		return XFW_MAKE_DROP_EXT(&key->src_addr, ctx->pkt_sz,
+					 XFW_L2_UNKNOWN_INGRESS,
+					 ": %x", bpf_htons(ctx->ipver));
 	}
 	}
 }
@@ -442,13 +474,13 @@ in_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key)
  * connection trusted.
  */
 static __always_inline int
-tcp_rcv_syn_filter(XfwGlobalCtx *ctx)
+tcp_rcv_syn_filter(XfwGlobalCtx *ctx, const XfwTcpConnKey *key)
 {
 	/* If a SYN cookie was generated, processing stops immediately. */
 	if (ctx->cfg->rules.syncookie.enabled)
-		CHAIN(tcp_syncookies_syn_filter, ctx);
+		CHAIN(tcp_syncookies_syn_filter, ctx, key);
 
-	CHAIN(syn_rlimit, ctx);
+	CHAIN(syn_rlimit, ctx, key);
 
 	/* We do not add the connection to the trusted set here.
 	 * The trusted entry will be created later in tc.c, which is less
@@ -467,25 +499,28 @@ tcp_rcv_syn_filter(XfwGlobalCtx *ctx)
  * 4. If valid, trust the connection on ingress side.
  */
 static __always_inline int
-tcp_rcv_ack_filter(const XfwGlobalCtx *ctx, const XfwSockAddr *addr)
+tcp_rcv_ack_filter(const XfwGlobalCtx *ctx, const XfwTcpConnKey *key)
 {
 	/* Fast path - no SYN cookies. */
 	if (!ctx->cfg->rules.syncookie.enabled)
-		return tcp_auth_conn_ingress_filter(ctx, addr, TCP_AUTH_EVENT_NORMAL);
+		return tcp_auth_conn_ingress_filter(ctx, key,
+						    TCP_AUTH_EVENT_NORMAL);
 
 	XfwTcpSynCookieTs *ts = __tcp_get_tcp_syncookie_ts();
 	XFW_ASSERT(ts);
 
 	/* Fast path - syncookies flood mode is inactive. */
 	if (!tcp_syncookies_flood_mode(ctx, ts))
-		return tcp_auth_conn_ingress_filter(ctx, addr, TCP_AUTH_EVENT_NORMAL);
+		return tcp_auth_conn_ingress_filter(ctx, key,
+						    TCP_AUTH_EVENT_NORMAL);
 
 	/* Can rely only on connections that are up-to-date */
-	if (ctx->cfg->rules.tcp_auth.enabled && tcp_auth_has_conn_trusted(ctx, addr))
+	if (ctx->cfg->rules.tcp_auth.enabled
+	    && tcp_auth_has_conn_trusted(ctx, key))
 		return XFW_CTX_CONTINUE;
 
 	/* Perform SYN-cookie-specific ACK validation */
-	CHAIN(tcp_syncookies_ack_filter, ctx);
+	CHAIN(tcp_syncookies_ack_filter, ctx, key);
 
 	/*
 	 * This is the scenario where a SYN cookie was issued and successfully
@@ -497,7 +532,7 @@ tcp_rcv_ack_filter(const XfwGlobalCtx *ctx, const XfwSockAddr *addr)
 	 * generated and sent directly by xdp.c, bypassing tc.c. This ensures
 	 * the connection is correctly tracked without relying on tc.c.
 	 */
-	tcp_auth_conn_add(addr);
+	tcp_auth_conn_add(key);
 	return XFW_CTX_CONTINUE;
 }
 
@@ -535,23 +570,23 @@ tcp_rcv_ack_filter(const XfwGlobalCtx *ctx, const XfwSockAddr *addr)
  * xdp.c for upstream connections.
  */
 static __always_inline int
-tcp_flags_filter(XfwGlobalCtx *ctx, const XfwSockAddr *addr)
+tcp_flags_filter(XfwGlobalCtx *ctx, const XfwTcpConnKey *key)
 {
 	const struct tcphdr *th = ctx->th;
 
 	/* FIN: track connection for closing. */
 	if (th->fin) {
 		count_traffic_stat(ctx, XFW_FIN);
-		return tcp_auth_conn_ingress_filter(ctx, addr,
+		return tcp_auth_conn_ingress_filter(ctx, key,
 						    TCP_AUTH_EVENT_FIN);
 	}
 
 	/* RST: clear connection state and apply rate-limiting. */
 	if (th->rst) {
 		count_traffic_stat(ctx, XFW_RST);
-		CHAIN(tcp_auth_conn_ingress_filter, ctx, addr,
+		CHAIN(tcp_auth_conn_ingress_filter, ctx, key,
 		      TCP_AUTH_EVENT_RST);
-		return rst_rlimit(ctx);
+		return rst_rlimit(ctx, key);
 	}
 
 	/*
@@ -562,62 +597,65 @@ tcp_flags_filter(XfwGlobalCtx *ctx, const XfwSockAddr *addr)
 	 */
 	if (th->syn && th->ack) {
 		count_traffic_stat(ctx, XFW_SYNACK);
-		return tcp_auth_conn_ingress_filter(ctx, addr,
+		return tcp_auth_conn_ingress_filter(ctx, key,
 						    TCP_AUTH_EVENT_NORMAL);
 	}
 
 	/* SYN-only. Authenticate the connection if all checks pass. */
 	if (th->syn) {
 		count_traffic_stat(ctx, XFW_SYN);
-		return tcp_rcv_syn_filter(ctx);
+		return tcp_rcv_syn_filter(ctx, key);
 	}
 
 	/* ACK-only: validate SYN-ACK cookies or authenticate normally.*/
 	if (th->ack) {
 		count_traffic_stat(ctx, XFW_ACK);
-		return tcp_rcv_ack_filter(ctx, addr);
+		return tcp_rcv_ack_filter(ctx, key);
 	}
 
 	/* Default: authenticate any remaining TCP packets. */
-	return tcp_auth_conn_ingress_filter(ctx, addr, TCP_AUTH_EVENT_NORMAL);
+	return tcp_auth_conn_ingress_filter(ctx, key, TCP_AUTH_EVENT_NORMAL);
 }
 
 static __always_inline int
-in_process_l4(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key)
+in_process_l4(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key, XfwTcpConnKey *key)
 {
 	if (!bpf_bitset64_test(ctx->cfg->rules.ip_proto.protocols.data,
 			       ctx->l4_proto))
 	{
-		return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_L4_UNSUPPORTED_INGRESS,
-					     ": %u", ctx->l4_proto);
+		return XFW_MAKE_DROP_EXT(&key->src_addr, ctx->pkt_sz,
+					 XFW_L4_UNSUPPORTED_INGRESS,
+					 ": %u", ctx->l4_proto);
 	}
 
 	switch (ctx->l4_proto) {
 	case XFW_L4_PROTO_TCP: {
 		count_traffic_stat(ctx, XFW_TCP_TOTAL_INGRESS);
 		if (unlikely(parse_tcphdr(&ctx->hdr_cur, &ctx->th) <= 0))
-			return XFW_MAKE_CTX_DROP(ctx, XFW_TCP_BADHDR_INGRESS);
+			return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+					     XFW_TCP_BADHDR_INGRESS);
 
-		CHAIN(tcp_anomaly_filter, ctx);
+		key->src_port = ctx->th->source;
+		key->dst_port = ctx->th->dest;
 
-		CHAIN(src_filter, ctx, ctx->th->source, src_ip_key);
-		
-		const XfwSockAddr addr = {
-			.addr = ctx->ilog_addr,
-			.port = ctx->th->source
-		};
-		return tcp_flags_filter(ctx, &addr);
+		CHAIN(tcp_anomaly_filter, ctx, key);
+
+		CHAIN(src_filter, ctx, key, ctx->th->source, src_ip_key);
+
+		return tcp_flags_filter(ctx, key);
 	}
 	case XFW_L4_PROTO_UDP: {
 		count_traffic_stat(ctx, XFW_UDP_TOTAL_INGRESS);
 		if (unlikely(parse_udphdr(&ctx->hdr_cur, &ctx->uh) <= 0))
-			return XFW_MAKE_CTX_DROP(ctx, XFW_UDP_BADHDR_INGRESS);
+			return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+					     XFW_UDP_BADHDR_INGRESS);
 
 		if (ctx->uh->source == 0 || ctx->uh->dest == 0)
-			return XFW_MAKE_CTX_DROP(ctx, XFW_UDP_ANOM_ZERO_PORT);
+			return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+					     XFW_UDP_ANOM_ZERO_PORT);
 
-		CHAIN(ingress_dns_filter, ctx);
-		return src_filter(ctx, ctx->uh->source, src_ip_key);
+		CHAIN(ingress_dns_filter, ctx, key);
+		return src_filter(ctx, key, ctx->uh->source, src_ip_key);
 	};
 	case XFW_L4_PROTO_ICMP:
 	case XFW_L4_PROTO_ICMPV6: {
@@ -625,16 +663,17 @@ in_process_l4(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key)
 
 		XfwICMPCommon *ih;
 		if (unlikely(parse_icmphdr_common(&ctx->hdr_cur, &ih) < 0))
-			return XFW_MAKE_CTX_DROP(ctx, XFW_ICMP_BADHDR_INGRESS);
+			return XFW_MAKE_DROP(&key->src_addr, ctx->pkt_sz,
+					     XFW_ICMP_BADHDR_INGRESS);
 
 		XFW_CTX_DBG("ICMP header parsed, type=%u", ih->type);
 
-		const XfwIcmpKey key = {
+		const XfwIcmpKey icmp_key = {
 			.proto = ctx->l4_proto,
 			.type = ih->type
 		};
-		CHAIN(icmp_filter, ctx, &key);
-		CHAIN(src_filter_ip, ctx, src_ip_key);
+		CHAIN(icmp_filter, ctx, key, &icmp_key);
+		CHAIN(src_filter_ip, ctx, key, src_ip_key);
 		/* ICMP has no destination port, so dst rules cannot refine this path. */
 		return XFW_CTX_PASS;
 	};
@@ -667,17 +706,19 @@ xfw_xdp_filter(struct XfwGlobalCtx *ctx)
 		return XFW_MAKE_CTX_PASS(ctx, XFW_PRELOAD_INGRESS);
 	}
 
+	XfwTcpConnKey key = {};
 	int ipver = parse_ethhdr(&ctx->hdr_cur, &ctx->eth);
 	if (unlikely(ipver < 0))
-		return XFW_MAKE_CTX_DROP(ctx, XFW_ETH_BADHDR_INGRESS);
+		return XFW_MAKE_DROP(&key.src_addr, ctx->pkt_sz,
+				     XFW_ETH_BADHDR_INGRESS);
 	ctx->ipver = ipver;
 
 	int r;
 	/* Helper structure for src filter, filled on L3, used on L4. */
 	XfwIpLpmKey src_ip_key = {};
-	CHAIN_PASS_ALL(in_process_l3, ctx, &src_ip_key);
-	CHAIN_PASS_ALL(in_process_l4, ctx, &src_ip_key);
-	CHAIN_PASS_ALL(xfw_dst_filter, ctx);
+	CHAIN_PASS_ALL(in_process_l3, ctx, &src_ip_key, &key);
+	CHAIN_PASS_ALL(in_process_l4, ctx, &src_ip_key, &key);
+	CHAIN_PASS_ALL(xfw_dst_filter, ctx, &key);
 
 pass:
 	count_traffic_stat(ctx, XFW_PASSED_DOWNSTREAM_INGRESS);

--- a/t/func/framework/asyn/tcp_client.py
+++ b/t/func/framework/asyn/tcp_client.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import logging
+import socket
 from abc import ABC
 from typing import Optional
 
@@ -48,7 +49,8 @@ class TCPClientProtocol(asyncio.Protocol):
 
 class TcpClient(BaseTcpStateful, ABC):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, reuse_addr: bool = False, *args, **kwargs):
+        self.reuse_addr = reuse_addr
         super().__init__(*args, **kwargs)
         self.protocol: Optional[TCPClientProtocol] = None
 
@@ -72,6 +74,12 @@ class TcpClient(BaseTcpStateful, ABC):
             ),
             timeout=self.timeout,
         )
+
+    def set_socket_options(self, sock: socket.socket):
+        super().set_socket_options(sock)
+
+        if self.reuse_addr:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
 
 class TcpV4Client(TcpClient, IP4Mixin): ...

--- a/t/func/framework/stateful.py
+++ b/t/func/framework/stateful.py
@@ -462,7 +462,13 @@ class SocketBaseNetworkStateful(NetworkStateful, abc.ABC):
 
     async def check_socket_closed(self, repeat=0, interval=0.1, retry=50):
         if self.socket_type == socket.SOCK_STREAM:
-            cmd = "ss -tan"
+            formatted_ip = self.ip_format(self.ip)
+            formatted_remote_ip = self.ip_format(self.remote_ip)
+            cmd = (
+                f"ss -tan "
+                f'| grep "{formatted_ip}:{self.port}" '
+                f'| grep "{formatted_remote_ip}:{self.remote_port}"'
+            )
         elif self.socket_type == socket.SOCK_DGRAM:
             cmd = "ss -uan"
         elif self.socket_type == socket.SOCK_RAW:

--- a/t/func/tests/test_tcp_auth_filter.py
+++ b/t/func/tests/test_tcp_auth_filter.py
@@ -2,12 +2,15 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 import asyncio
+import socket
 
 import pytest
 from scapy.layers.inet import TCP
 
+from config import ConfigSettings
 from framework.asyn import TcpClient, TcpRawClient, TcpRawServer, TcpServer
 from framework.cmp import check_connection
+from framework.fabrics import client_fabric, server_fabric
 from framework.xfw import XFW
 
 
@@ -225,3 +228,113 @@ async def test_allow_tcp_flood_after_connection(
     assert (
         await tcp_raw_server.receive_tcp_flags() == tcp_flag
     ), f"TCP packet with {tcp_flag} with session is not allowed"
+
+
+async def test_reset_one_connection_does_not_break_another(
+    xfw: XFW,
+    tcp_server: TcpServer,
+    tcp_client: TcpClient,
+    config: ConfigSettings,
+    logging_level: int,
+    rpc_connection,
+):
+    """
+    Resetting one authenticated TCP connection must not remove the
+    authentication state of another connection with the same client
+    endpoint but a different server address.
+    """
+    await xfw.rules_set("xfw { tcp_auth_filter; }")
+
+    first_server_ip, second_server_ip = tcp_server.generate_new_addresses(2)
+    server_ip_param = "ipv4" if tcp_server.socket_family == socket.AF_INET else "ipv6"
+
+    first_server = server_fabric(
+        config=config,
+        logging_level=logging_level,
+        rpc_connection=rpc_connection,
+        local_class=type(tcp_server),
+        remote_class=type(tcp_server),
+        port=tcp_server.port,
+        echo_mode=True,
+        **{server_ip_param: first_server_ip},
+    )
+
+    second_server = server_fabric(
+        config=config,
+        logging_level=logging_level,
+        rpc_connection=rpc_connection,
+        local_class=type(tcp_server),
+        remote_class=type(tcp_server),
+        port=tcp_server.port,
+        echo_mode=True,
+        **{server_ip_param: second_server_ip},
+    )
+
+    #
+    # Both connections intentionally use the same client IP:port.
+    # They differ only by the server address.
+    #
+    #   client_ip:port -> server1_ip:port
+    #   client_ip:port -> server2_ip:port
+    #
+    first_client = client_fabric(
+        config=config,
+        logging_level=logging_level,
+        local_class=type(tcp_client),
+        port=tcp_client.port + 1,
+        remote_ip=first_server.ip,
+        remote_port=first_server.port,
+        reuse_addr=True,
+    )
+
+    second_client = client_fabric(
+        config=config,
+        logging_level=logging_level,
+        local_class=type(tcp_client),
+        port=tcp_client.port + 1,
+        remote_ip=second_server.ip,
+        remote_port=second_server.port,
+        reuse_addr=True,
+    )
+
+    await first_server.start()
+    await second_server.start()
+    await first_client.start()
+    await second_client.start()
+
+    try:
+        assert first_client.ip == second_client.ip
+        assert first_client.port == second_client.port
+
+        assert first_client.remote_ip != second_client.remote_ip
+        assert first_client.remote_port == second_client.remote_port
+
+        # Establish and verify both independent TCP connections.
+        await first_client.ping_pong()
+        await second_client.ping_pong()
+
+        #
+        # Reset only the first connection.
+        #
+        # With the old endpoint-only TCP AUTH key, both connections had
+        # the same authentication key on the server-to-client path:
+        #
+        #   client_ip:port
+        #
+        # Therefore, resetting the first connection could remove the
+        # authentication state used by the second one.
+        #
+        first_client.use_rst_for_connection_closing()
+        first_client.transport.abort()
+
+        await asyncio.sleep(0)
+
+        # Must use the already established second connection.
+        # No reconnect is allowed here.
+        await second_client.ping_pong()
+
+    finally:
+        await first_client.stop()
+        await second_client.stop()
+        await first_server.stop()
+        await second_server.stop()


### PR DESCRIPTION
tcp_auth: track connections by full TCP 4-tuple

TCP AUTH previously used XfwSockAddr as the connection-tracking key.
The key contained only one IP address and one TCP port, so it identified
an endpoint rather than an individual TCP connection.

This was incorrect for connection tracking because multiple independent
connections can share the same endpoint.

For example, consider several concurrent TCP connections passing through
xFW to the same protected service:

    192.168.122.13:57488 -> 192.168.122.199:443
    192.168.122.13:57490 -> 192.168.122.199:443
    192.168.122.13:57656 -> 192.168.122.199:443

On the TC egress path, all of these connections were represented by the
same destination endpoint:

    192.168.122.199:443

The same endpoint was then used by XDP as the source key for packets
arriving in the reverse direction.

As a result, unrelated TCP connections shared the same authentication
state. This was especially harmful for RST and FIN processing. An RST
belonging to one connection could delete the common
192.168.122.199:443 entry, causing subsequent packets belonging to other
still valid connections to miss the authentication map and be dropped.

This was observed in tests creating many concurrent connections. For
example, after the state associated with

    192.168.122.199:443 -> 192.168.122.13:57488

was removed by an RST, a packet belonging to

    192.168.122.199:443 -> 192.168.122.13:57490

looked up the same old endpoint key and missed the authentication map.

Replace XfwSockAddr with XfwTcpConnKey containing the complete TCP
4-tuple:

    source IP
    destination IP
    source port
    destination port

XDP constructs the key in the current packet direction. TC egress
constructs the tuple in the reverse direction so that the entry it
creates matches the key that XDP will use when the reply packet arrives.

Thus, the two directions of a TCP connection remain represented by
directional entries, but each entry now identifies the complete TCP
flow instead of only one endpoint. Connections sharing the same server
endpoint therefore no longer share authentication state.

The connection key is populated during packet parsing and is also passed
to filters which need the source address for incident accounting. This
allows the old ilog_addr fields to be removed from XfwGlobalCtx and
XfwDnsCtx, avoiding an additional copy of the packet source address.
This also helps reduce BPF stack usage introduced by the larger
XfwTcpConnKey.

Use the complete tuple itself as the BPF map key instead of storing an
XXH64 fingerprint as done by TCP SYN drop.

The SYN-drop maps intentionally use compact 64-bit tuple fingerprints.
They operate as an attack-mitigation mechanism where an extremely rare
hash collision is an acceptable trade-off for smaller keys and cheaper
state under very high SYN rates.

TCP AUTH has different correctness and security requirements. A collision
in an externally computed 64-bit fingerprint would make two different
TCP connections indistinguishable to the BPF map. Depending on the
operation, this could cause one connection to authenticate, expire, or
delete the state of another connection.

BPF_MAP_TYPE_LRU_HASH already hashes its keys internally. When the full
4-tuple is used as the map key, an internal hash collision only places
different keys in the same hash bucket; the map still compares the full
keys and keeps the connections distinct. Pre-hashing the tuple to 64 bits
would discard that information before the BPF map sees the key and make
such collisions impossible to resolve.

Therefore TCP AUTH stores the full 4-tuple despite its larger key size,
while TCP SYN drop continues to use compact XXH64 fingerprints where
that trade-off is appropriate.

Also perform minor code-style cleanup in the affected code and wrap
several long lines to comply with the 80-column limit.