### PR TITLE
Mekhanik evgenii/fix tcp auth 67 1

### DIFF
--- a/bpf/ctx.h
+++ b/bpf/ctx.h
@@ -59,6 +59,7 @@ typedef struct XfwHdrCursor {
 typedef struct XfwGlobalCtx {
 	XfwFilterCfg	*cfg;
 	XfwPerCpuStats	*g_stats;
+	XfwTcpConnAddr	addr;
 	XfwHdrCursor	hdr_cur;
 	uint32_t	pkt_sz;
 	uint16_t	ipver;
@@ -75,7 +76,6 @@ typedef struct XfwGlobalCtx {
 		struct udphdr	*uh;
 	};
 	uint64_t	ts_jiff;
-	XfwIp		ilog_addr;
 } XfwGlobalCtx;
 
 /* Read-only for eBPF. */

--- a/bpf/dns.h
+++ b/bpf/dns.h
@@ -95,8 +95,8 @@ STATIC_ASSERT(sizeof(XfwPacketMetadata) <= 32,
 typedef struct XfwDnsCtx {
 	XfwMd		*ctx;
 	XfwPerCpuStats	*g_stats;
+	XfwTcpConnAddr	addr;
 	XfwHdrCursor	hdr_cur;
-	XfwIp		ilog_addr;
 	uint32_t	pkt_sz;
 } XfwDnsCtx;
 
@@ -365,13 +365,15 @@ init_dns_ctx(XfwDnsCtx *dns_ctx, XfwMd *ctx, XfwPerCpuStats *global_stats)
 		struct iphdr *ipv4 = ip_hdr;
 		if (unlikely((void*)(ipv4 + 1) > dns_ctx->hdr_cur.end))
 			return -1;
-		xfw_ipv4_to_ipv6_mapped(ipv4->saddr, dns_ctx->ilog_addr.addr32);
+		xfw_ipv4_to_ipv6_mapped(ipv4->saddr, dns_ctx->addr.src_addr.addr32);
+		xfw_ipv4_to_ipv6_mapped(ipv4->daddr, dns_ctx->addr.dst_addr.addr32);
 	}
 	else {
 		struct ipv6hdr *ipv6 = ip_hdr;
 		if (unlikely((void*)(ipv6 + 1) > dns_ctx->hdr_cur.end))
 			return -1;
-		dns_ctx->ilog_addr.in6 = ipv6->saddr;
+		dns_ctx->addr.src_addr.in6 = ipv6->saddr;
+		dns_ctx->addr.dst_addr.in6 = ipv6->daddr;
 	}
 
 	dns_ctx->pkt_sz = XFW_CTX_MD(ctx)->data_end - XFW_CTX_MD(ctx)->data;

--- a/bpf/incident_log.h
+++ b/bpf/incident_log.h
@@ -175,4 +175,4 @@ register_incident(const XfwIp* ilog_addr, uint32_t pkt_sz, enum XfwDropStat reas
 }
 
 #define REGISTER_INCIDENT(ctx, reason)					\
-	register_incident(&(ctx)->ilog_addr, (ctx)->pkt_sz, reason)
+	register_incident(&(ctx)->addr.src_addr, (ctx)->pkt_sz, reason)

--- a/bpf/tc.c
+++ b/bpf/tc.c
@@ -48,7 +48,8 @@ out_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey* prot_net_key, void **prot_net_map
 			return XFW_MAKE_CTX_PASS(ctx, XFW_IP4_BADHDR_EGRESS);
 
 		ctx->l4_proto = (u8)proto;
-		xfw_ipv4_to_ipv6_mapped(ctx->iph4->daddr, ctx->ilog_addr.addr32);
+		xfw_ipv4_to_ipv6_mapped(ctx->iph4->daddr, ctx->addr.src_addr.addr32);
+		xfw_ipv4_to_ipv6_mapped(ctx->iph4->saddr, ctx->addr.dst_addr.addr32);
 		ipv4_populate_lpm_key(ctx->iph4->daddr, &prot_net_key->addr4);
 		*prot_net_map = SELECT_SHADOW_MAP(MAP_NET_IP4_BASENAME,
 						   ctx->cfg->amap_prot_net);
@@ -62,7 +63,8 @@ out_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey* prot_net_key, void **prot_net_map
 			return XFW_MAKE_CTX_PASS(ctx, XFW_IP6_BADHDR_EGRESS);
 
 		ctx->l4_proto = (u8)proto;
-		ctx->ilog_addr.in6 = ctx->iph6->daddr;
+		ctx->addr.src_addr.in6 = ctx->iph6->daddr;
+		ctx->addr.dst_addr.in6 = ctx->iph6->saddr;
 		ipv6_populate_lpm_key(&ctx->iph6->daddr, &prot_net_key->addr6);
 		*prot_net_map = SELECT_SHADOW_MAP(MAP_NET_IP6_BASENAME,
 						   ctx->cfg->amap_prot_net);
@@ -88,6 +90,8 @@ out_process_l4(XfwGlobalCtx *ctx)
 		if (unlikely(parse_tcphdr(&ctx->hdr_cur, &ctx->th) <= 0))
 			return XFW_MAKE_CTX_PASS(ctx, XFW_TCP_BADHDR_EGRESS);
 
+		ctx->addr.src_port = ctx->th->dest;
+		ctx->addr.dst_port = ctx->th->source;
 		/* It is a regular case, don't need to add any statistic */
 		return XFW_CTX_CONTINUE;
 	}

--- a/bpf/tcp_auth.h
+++ b/bpf/tcp_auth.h
@@ -201,7 +201,7 @@ tcp_auth_conn_egress_learning(const XfwGlobalCtx *ctx)
 	VERIFY_TRUE_OR_RETURN((void *)(th + 1) <= ctx->hdr_cur.end, (void)0);
 
 	const XfwSockAddr addr = {
-		.addr = ctx->ilog_addr,
+		.addr = ctx->addr.src_addr,
 		.port = th->dest
 	};
 	

--- a/bpf/tcp_auth.h
+++ b/bpf/tcp_auth.h
@@ -48,19 +48,12 @@
 
 #include "filter.h"
 
-typedef struct XfwSockAddr {
-	XfwIp		addr; /* IPv4 uses the low 32 bits; the rest stays zero. */
-	XfwPort		port;
-	uint8_t		__reserved[2];
-} XfwSockAddr;
-STATIC_ASSERT(sizeof(XfwSockAddr) == 20, "Invalid XfwSockAddr size");
-
 /*
  * For TCP Authentication Filter there are only 2 states for a connection:
  * unauthenticated (no XfwTcpConnState entry in the map) and authenticated
  * (a map entry exists).
  *
- * @last_fin_time	- timestamp in seconds for the last seen FIN
+ * @last_fin_time_jiff	- timestamp in jiffies for the last seen FIN
  */
 typedef struct XfwTcpConnState {
 	uint64_t		last_fin_time_jiff; /* In jiffies */
@@ -68,7 +61,7 @@ typedef struct XfwTcpConnState {
 
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
-	__type(key, XfwSockAddr);
+	__type(key, XfwTcpConnAddr);
 	__type(value, XfwTcpConnState);
 	/* Pinned so ingress and egress programs share authenticated sockets. */
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
@@ -87,20 +80,20 @@ struct {
 	(UINT64_MAX - TCP_AUTH_CONN_CLOSE_TIMEOUT_JIFF) /* Keep timeout math bounded. */
 
 static __always_inline XfwTcpConnState *
-tcp_auth_conn_lookup(const XfwSockAddr *addr)
+tcp_auth_conn_lookup(const XfwTcpConnAddr *addr)
 {
 	return bpf_map_lookup_elem(&MAP_TCP_CONN_REF, addr);
 }
 
 static __always_inline void
-tcp_auth_conn_delete(const XfwSockAddr *addr)
+tcp_auth_conn_delete(const XfwTcpConnAddr *addr)
 {
 	bpf_map_delete_elem(&MAP_TCP_CONN_REF, addr);
 	XFW_CTX_DBG("Delete TCP AUTH connection");
 }
 
 static __always_inline void
-tcp_auth_conn_add(const XfwSockAddr *addr)
+tcp_auth_conn_add(const XfwTcpConnAddr *addr)
 {
 	XfwTcpConnState new_conn = {
 		.last_fin_time_jiff = TCP_AUTH_CONN_MAX_FIN_TIME_JIFF
@@ -125,7 +118,7 @@ tcp_auth_is_conn_outdated(const XfwGlobalCtx *ctx, const XfwTcpConnState *conn)
 }
 
 static __always_inline bool
-tcp_auth_has_conn_trusted(const XfwGlobalCtx *ctx, const XfwSockAddr *addr)
+tcp_auth_has_conn_trusted(const XfwGlobalCtx *ctx, const XfwTcpConnAddr *addr)
 {
 	XfwTcpConnState *conn = tcp_auth_conn_lookup(addr);
 
@@ -160,18 +153,17 @@ enum XfwTcpAuthEvent {
  * keeping the per-packet cost minimal.
  */
 static __always_inline int
-tcp_auth_conn_ingress_filter(const XfwGlobalCtx *ctx, const XfwSockAddr *addr,
-			     enum XfwTcpAuthEvent ev)
+tcp_auth_conn_ingress_filter(const XfwGlobalCtx *ctx, enum XfwTcpAuthEvent ev)
 {
 	if (unlikely(!ctx->cfg->rules.tcp_auth.enabled))
 		return XFW_CTX_CONTINUE;
 
-	XfwTcpConnState *conn = tcp_auth_conn_lookup(addr);
+	XfwTcpConnState *conn = tcp_auth_conn_lookup(&ctx->addr);
 	if (likely(!(conn))) /* Fast path for unauthenticated flood traffic. */
 		return XFW_MAKE_CTX_DROP(ctx, XFW_DROP_TCP_AUTH_FAILED);
 
 	if (unlikely(tcp_auth_is_conn_outdated(ctx, (conn)))) {
-		tcp_auth_conn_delete(addr);
+		tcp_auth_conn_delete(&ctx->addr);
 		return XFW_MAKE_CTX_DROP(ctx, XFW_DROP_TCP_AUTH_TIMEOUT);
 	}
 
@@ -181,7 +173,7 @@ tcp_auth_conn_ingress_filter(const XfwGlobalCtx *ctx, const XfwSockAddr *addr,
 		 * Out-of-order traffic: early RST clears the connection,
 		 * mirroring TCP stack behavior.
 		 */
-		tcp_auth_conn_delete(addr);
+		tcp_auth_conn_delete(&ctx->addr);
 		return XFW_CTX_CONTINUE;
 
 	case TCP_AUTH_EVENT_FIN:
@@ -200,18 +192,13 @@ tcp_auth_conn_egress_learning(const XfwGlobalCtx *ctx)
 	struct tcphdr *th = ctx->th;
 	VERIFY_TRUE_OR_RETURN((void *)(th + 1) <= ctx->hdr_cur.end, (void)0);
 
-	const XfwSockAddr addr = {
-		.addr = ctx->addr.src_addr,
-		.port = th->dest
-	};
-	
 	if (unlikely(th->rst)) {
 		/* An early RST can safely remove a learned tuple. */
-		tcp_auth_conn_delete(&addr);
+		tcp_auth_conn_delete(&ctx->addr);
 		return;
 	}
 
-	XfwTcpConnState *conn = tcp_auth_conn_lookup(&addr);
+	XfwTcpConnState *conn = tcp_auth_conn_lookup(&ctx->addr);
 
 	/*
 	 * Trusted connection tracking in tc.c has two modes:
@@ -237,7 +224,7 @@ tcp_auth_conn_egress_learning(const XfwGlobalCtx *ctx)
 	 */
 	if (!conn) {
 		if (unlikely(!ctx->cfg->rules.tcp_auth.enabled || th->syn))
-			tcp_auth_conn_add(&addr);
+			tcp_auth_conn_add(&ctx->addr);
 		return;
 	}
 

--- a/bpf/xdp.c
+++ b/bpf/xdp.c
@@ -227,6 +227,7 @@ populate_src_info(const XfwGlobalCtx *ctx, void **src_ip_map,
 {
 	if (ctx->ipver == bpf_htons(ETH_P_IPV6))
 	{
+		ipv6_populate_lpm_key(&ctx->addr.src_addr.in6, &ip_lpm->addr6);
 		if (ctx->l4_proto == XFW_L4_PROTO_UDP) {
 			*src_default = XFW_DEFAULT_SRC_IP_UDP_IP6;
 			*src_ip_map =  SELECT_SHADOW_MAP(MAP_SRC_6_UDP_BASENAME,
@@ -239,6 +240,8 @@ populate_src_info(const XfwGlobalCtx *ctx, void **src_ip_map,
 		}
 	}
 	else { /* ETH_P_IP */
+		ipv4_populate_lpm_key(ctx->addr.src_addr.addr32[3],
+				      &ip_lpm->addr4);
 		if (ctx->l4_proto == XFW_L4_PROTO_UDP) {
 			*src_default = XFW_DEFAULT_SRC_IP_UDP_IP4;
 			*src_ip_map = SELECT_SHADOW_MAP(MAP_SRC_4_UDP_BASENAME,
@@ -261,30 +264,34 @@ populate_src_info(const XfwGlobalCtx *ctx, void **src_ip_map,
  * information) in addition to the IP address.
  */
 static __always_inline int
-src_filter_ip(const XfwGlobalCtx *ctx, XfwIpLpmKey *ip_lpm)
+src_filter_ip(const XfwGlobalCtx *ctx)
 {
+	XfwIpLpmKey ip_lpm = {};
 	uint8_t src_default;
 	void *src_ip_map;
-	populate_src_info(ctx, &src_ip_map, ip_lpm, &src_default);
 
-	XfwSrcRule *rule = bpf_map_lookup_elem(src_ip_map, ip_lpm);
+	populate_src_info(ctx, &src_ip_map, &ip_lpm, &src_default);
+
+	XfwSrcRule *rule = bpf_map_lookup_elem(src_ip_map, &ip_lpm);
 
 	if (rule) {
 		switch (rule->action) {
 		case XFW_ACTION_BLOCK:
 			return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_DROP_SRC_IP_BLOCKED,
-						     ": %pI6", &ctx->ilog_addr.in6);
+						     ": %pI6",
+						     &ctx->addr.src_addr.in6);
 
 		case XFW_ACTION_ALLOW:
 			return XFW_MAKE_CTX_PASS_EXT(ctx, XFW_SRC_IP_ALLOWED,
-						     ": %pI6", &ctx->ilog_addr.in6);
+						     ": %pI6",
+						     &ctx->addr.src_addr.in6);
 		default:
 			/* XFW_ACTION_RATE_LIMIT */
 			XFW_ASSERT(rule->action == XFW_ACTION_RATE_LIMIT);
 
 			XfwRLimitSlidingWindow *b = XFW_MAP_LOOKUP_OR_INIT(
 							&MAP_SRC_RATELIM_REF,
-							&ctx->ilog_addr.in6,
+							&ctx->addr.src_addr.in6,
 							XfwRLimitSlidingWindow);
 			XFW_ASSERT(b);
 
@@ -294,14 +301,14 @@ src_filter_ip(const XfwGlobalCtx *ctx, XfwIpLpmKey *ip_lpm)
 						 b))
 				return XFW_CTX_CONTINUE;
 			return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_DROP_SRC_IP_RATE_LIMITED,
-						     ": %pI6", &ctx->ilog_addr.in6);
+						     ": %pI6", &ctx->addr.src_addr.in6);
 		}
 	}
 
 	XfwActionRule *default_rule = &ctx->cfg->rules.defaults[src_default];
 	if (default_rule->action == XFW_ACTION_BLOCK)
 		return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_DROP_SRC_IP_DEFAULT_BLOCKED,
-					     ": %pI6", &ctx->ilog_addr.in6);
+					     ": %pI6", &ctx->addr.src_addr.in6);
 
 	if (default_rule->action == XFW_ACTION_ALLOW)
 		return XFW_CTX_CONTINUE;
@@ -309,7 +316,7 @@ src_filter_ip(const XfwGlobalCtx *ctx, XfwIpLpmKey *ip_lpm)
 	XFW_ASSERT(default_rule->action == XFW_ACTION_RATE_LIMIT);
 
 	XfwRLimitSlidingWindow *b = XFW_MAP_LOOKUP_OR_INIT(&MAP_SRC_RATELIM_REF,
-						       &ctx->ilog_addr.in6,
+						       &ctx->addr.src_addr.in6,
 						       XfwRLimitSlidingWindow);
 	XFW_ASSERT(b);
 
@@ -320,7 +327,7 @@ src_filter_ip(const XfwGlobalCtx *ctx, XfwIpLpmKey *ip_lpm)
 		return XFW_CTX_CONTINUE;
 
 	return XFW_MAKE_CTX_DROP_EXT(ctx, XFW_DROP_SRC_IP_DEFAULT_RATE_LIMITED,
-				     ": %pI6", &ctx->ilog_addr.in6);
+				     ": %pI6", &ctx->addr.src_addr.in6);
 }
 
 /**
@@ -330,9 +337,9 @@ src_filter_ip(const XfwGlobalCtx *ctx, XfwIpLpmKey *ip_lpm)
  * We need to change the configuration to be able to split the layers.
  */
 static __always_inline int
-src_filter(const XfwGlobalCtx *ctx, XfwPort src_port, XfwIpLpmKey* src_ip_key)
+src_filter(const XfwGlobalCtx *ctx, XfwPort src_port)
 {
-	CHAIN(src_filter_ip, ctx, src_ip_key);
+	CHAIN(src_filter_ip, ctx);
 	CHAIN(src_filter_port, ctx, src_port);
 
 	return XFW_CTX_CONTINUE;
@@ -366,7 +373,7 @@ syn_rlimit(XfwGlobalCtx *ctx)
 }
 
 static __always_inline int
-in_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key)
+in_process_l3(XfwGlobalCtx *ctx)
 {
 	switch (ctx->ipver) {
 	case bpf_ntohs(ETH_P_IP): {
@@ -380,8 +387,8 @@ in_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key)
 			return XFW_MAKE_CTX_DROP(ctx, XFW_DROP_IP4_FRAGMENTED_INGRESS);
 
 		ctx->l4_proto = (u8)proto;
-		xfw_ipv4_to_ipv6_mapped(ctx->iph4->saddr, ctx->ilog_addr.addr32);
-		ipv4_populate_lpm_key(ctx->iph4->saddr, &src_ip_key->addr4);
+		xfw_ipv4_to_ipv6_mapped(ctx->iph4->saddr, ctx->addr.src_addr.addr32);
+		xfw_ipv4_to_ipv6_mapped(ctx->iph4->daddr, ctx->addr.dst_addr.addr32);
 		return XFW_CTX_CONTINUE;
 	}
 	case bpf_ntohs(ETH_P_IPV6): {
@@ -394,8 +401,8 @@ in_process_l3(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key)
 		}
 
 		ctx->l4_proto = (u8)proto;
-		ctx->ilog_addr.in6 = ctx->iph6->saddr;
-		ipv6_populate_lpm_key(&ctx->iph6->saddr, &src_ip_key->addr6);
+		ctx->addr.src_addr.in6 = ctx->iph6->saddr;
+		ctx->addr.dst_addr.in6 = ctx->iph6->daddr;
 
 		return XFW_CTX_CONTINUE;
 	}
@@ -557,7 +564,7 @@ tcp_flags_filter(XfwGlobalCtx *ctx, const XfwSockAddr *addr)
 }
 
 static __always_inline int
-in_process_l4(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key)
+in_process_l4(XfwGlobalCtx *ctx)
 {
 	if (!bpf_bitset64_test(ctx->cfg->rules.ip_proto.protocols.data,
 			       ctx->l4_proto))
@@ -572,12 +579,14 @@ in_process_l4(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key)
 		if (unlikely(parse_tcphdr(&ctx->hdr_cur, &ctx->th) <= 0))
 			return XFW_MAKE_CTX_DROP(ctx, XFW_DROP_TCP_BADHDR_INGRESS);
 
+		ctx->addr.src_port = ctx->th->source;
+		ctx->addr.dst_port = ctx->th->dest;
 		CHAIN(tcp_anomaly_filter, ctx);
 
-		CHAIN(src_filter, ctx, ctx->th->source, src_ip_key);
+		CHAIN(src_filter, ctx, ctx->th->source);
 
 		const XfwSockAddr addr = {
-			.addr = ctx->ilog_addr,
+			.addr = ctx->addr.src_addr,
 			.port = ctx->th->source
 		};
 		return tcp_flags_filter(ctx, &addr);
@@ -591,7 +600,7 @@ in_process_l4(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key)
 			return XFW_MAKE_CTX_DROP(ctx, XFW_DROP_UDP_ANOM_ZERO_PORT);
 
 		CHAIN(ingress_dns_filter, ctx);
-		return src_filter(ctx, ctx->uh->source, src_ip_key);
+		return src_filter(ctx, ctx->uh->source);
 	};
 	case XFW_L4_PROTO_ICMP:
 	case XFW_L4_PROTO_ICMPV6: {
@@ -608,7 +617,7 @@ in_process_l4(XfwGlobalCtx *ctx, XfwIpLpmKey *src_ip_key)
 			.type = ih->type
 		};
 		CHAIN(icmp_filter, ctx, &key);
-		CHAIN(src_filter_ip, ctx, src_ip_key);
+		CHAIN(src_filter_ip, ctx);
 		/* ICMP has no destination port, so dst rules cannot refine this path. */
 		return XFW_CTX_PASS;
 	};
@@ -647,10 +656,8 @@ xfw_xdp_filter(struct XfwGlobalCtx *ctx)
 	ctx->ipver = ipver;
 
 	int r;
-	/* Helper structure for src filter, filled on L3, used on L4. */
-	XfwIpLpmKey src_ip_key = {};
-	CHAIN_PASS_ALL(in_process_l3, ctx, &src_ip_key);
-	CHAIN_PASS_ALL(in_process_l4, ctx, &src_ip_key);
+	CHAIN_PASS_ALL(in_process_l3, ctx);
+	CHAIN_PASS_ALL(in_process_l4, ctx);
 	CHAIN_PASS_ALL(xfw_dst_filter, ctx);
 
 pass:

--- a/bpf/xdp.c
+++ b/bpf/xdp.c
@@ -448,21 +448,22 @@ tcp_rcv_syn_filter(XfwGlobalCtx *ctx)
  * 4. If valid, trust the connection on ingress side.
  */
 static __always_inline int
-tcp_rcv_ack_filter(const XfwGlobalCtx *ctx, const XfwSockAddr *addr)
+tcp_rcv_ack_filter(const XfwGlobalCtx *ctx)
 {
 	/* Fast path - no SYN cookies. */
 	if (!ctx->cfg->rules.syncookie.enabled)
-		return tcp_auth_conn_ingress_filter(ctx, addr, TCP_AUTH_EVENT_NORMAL);
+		return tcp_auth_conn_ingress_filter(ctx, TCP_AUTH_EVENT_NORMAL);
 
 	XfwTcpSynCookieTs *ts = __tcp_get_tcp_syncookie_ts();
 	XFW_ASSERT(ts);
 
 	/* Fast path - syncookies flood mode is inactive. */
 	if (!tcp_syncookies_flood_mode(ctx, ts))
-		return tcp_auth_conn_ingress_filter(ctx, addr, TCP_AUTH_EVENT_NORMAL);
+		return tcp_auth_conn_ingress_filter(ctx, TCP_AUTH_EVENT_NORMAL);
 
 	/* Can rely only on connections that are up-to-date */
-	if (ctx->cfg->rules.tcp_auth.enabled && tcp_auth_has_conn_trusted(ctx, addr))
+	if (ctx->cfg->rules.tcp_auth.enabled
+	    && tcp_auth_has_conn_trusted(ctx, &ctx->addr))
 		return XFW_CTX_CONTINUE;
 
 	/* Perform SYN-cookie-specific ACK validation */
@@ -478,7 +479,7 @@ tcp_rcv_ack_filter(const XfwGlobalCtx *ctx, const XfwSockAddr *addr)
 	 * generated and sent directly by xdp.c, bypassing tc.c. This ensures
 	 * the connection is correctly tracked without relying on tc.c.
 	 */
-	tcp_auth_conn_add(addr);
+	tcp_auth_conn_add(&ctx->addr);
 	return XFW_CTX_CONTINUE;
 }
 
@@ -516,22 +517,20 @@ tcp_rcv_ack_filter(const XfwGlobalCtx *ctx, const XfwSockAddr *addr)
  * xdp.c for upstream connections.
  */
 static __always_inline int
-tcp_flags_filter(XfwGlobalCtx *ctx, const XfwSockAddr *addr)
+tcp_flags_filter(XfwGlobalCtx *ctx)
 {
 	const struct tcphdr *th = ctx->th;
 
 	/* FIN: track connection for closing. */
 	if (th->fin) {
 		count_traffic_stat(ctx, XFW_FIN);
-		return tcp_auth_conn_ingress_filter(ctx, addr,
-						    TCP_AUTH_EVENT_FIN);
+		return tcp_auth_conn_ingress_filter(ctx, TCP_AUTH_EVENT_FIN);
 	}
 
 	/* RST: clear connection state and apply rate-limiting. */
 	if (th->rst) {
 		count_traffic_stat(ctx, XFW_RST);
-		CHAIN(tcp_auth_conn_ingress_filter, ctx, addr,
-		      TCP_AUTH_EVENT_RST);
+		CHAIN(tcp_auth_conn_ingress_filter, ctx, TCP_AUTH_EVENT_RST);
 		return rst_rlimit(ctx);
 	}
 
@@ -543,8 +542,7 @@ tcp_flags_filter(XfwGlobalCtx *ctx, const XfwSockAddr *addr)
 	 */
 	if (th->syn && th->ack) {
 		count_traffic_stat(ctx, XFW_SYNACK);
-		return tcp_auth_conn_ingress_filter(ctx, addr,
-						    TCP_AUTH_EVENT_NORMAL);
+		return tcp_auth_conn_ingress_filter(ctx, TCP_AUTH_EVENT_NORMAL);
 	}
 
 	/* SYN-only. Authenticate the connection if all checks pass. */
@@ -556,11 +554,11 @@ tcp_flags_filter(XfwGlobalCtx *ctx, const XfwSockAddr *addr)
 	/* ACK-only: validate SYN-ACK cookies or authenticate normally.*/
 	if (th->ack) {
 		count_traffic_stat(ctx, XFW_ACK);
-		return tcp_rcv_ack_filter(ctx, addr);
+		return tcp_rcv_ack_filter(ctx);
 	}
 
 	/* Default: authenticate any remaining TCP packets. */
-	return tcp_auth_conn_ingress_filter(ctx, addr, TCP_AUTH_EVENT_NORMAL);
+	return tcp_auth_conn_ingress_filter(ctx, TCP_AUTH_EVENT_NORMAL);
 }
 
 static __always_inline int
@@ -585,11 +583,7 @@ in_process_l4(XfwGlobalCtx *ctx)
 
 		CHAIN(src_filter, ctx, ctx->th->source);
 
-		const XfwSockAddr addr = {
-			.addr = ctx->addr.src_addr,
-			.port = ctx->th->source
-		};
-		return tcp_flags_filter(ctx, &addr);
+		return tcp_flags_filter(ctx);
 	}
 	case XFW_L4_PROTO_UDP: {
 		count_traffic_stat(ctx, XFW_UDP_TOTAL_INGRESS);

--- a/bpf_uapi/ip_helpers.h
+++ b/bpf_uapi/ip_helpers.h
@@ -27,7 +27,7 @@ xfw_ipv4_to_ipv6_mapped(__be32 ipv4, __be32 addr[4])
 	addr[3] = ipv4;
 }
 
-static __always_inline int
+static __always_inline bool
 xfw_is_ipv6_mapped_to_ipv4(const __be32 addr[4])
 {
 	return (addr[0] == 0 && addr[1] == 0 &&

--- a/bpf_uapi/types.h
+++ b/bpf_uapi/types.h
@@ -103,6 +103,25 @@ typedef union {
 	struct in6_addr	in6;
 } XfwIp;
 
+/*
+ * Full TCP connection tracking address container.
+ *
+ * The full TCP 4-tuple is used to uniquely identify a connection and keep
+ * connections sharing the same endpoint in separate authentication states.
+ *
+ * Always normalized to the client-to-server direction regardless
+ * of the packet direction. For ingress traffic, source and destination are
+ * used as-is. For egress traffic, they are reversed so that packets in both
+ * directions of the same connection resolve to the same map entry.
+ */
+typedef struct XfwTcpConnAddr {
+	XfwIp		src_addr;
+	XfwIp		dst_addr;
+	XfwPort		src_port;
+	XfwPort		dst_port;
+} XfwTcpConnAddr;
+
 STATIC_ASSERT(sizeof(XfwIp) == sizeof(struct in6_addr), "Invalid XfwIp size");
 STATIC_ASSERT(sizeof(XfwIp) == sizeof(__be32[4]), "Invalid XfwIp size");
 STATIC_ASSERT(sizeof(XfwIp) == 16, "Invalid XfwIp size");
+STATIC_ASSERT(sizeof(XfwTcpConnAddr) == 36, "Invalid XfwTcpConnAddr size");

--- a/t/func/framework/asyn/tcp_client.py
+++ b/t/func/framework/asyn/tcp_client.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import logging
+import socket
 from abc import ABC
 from typing import Optional
 
@@ -48,8 +49,9 @@ class TCPClientProtocol(asyncio.Protocol):
 
 class TcpClient(BaseTcpStateful, ABC):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, reuse_addr: bool = False, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.reuse_addr = reuse_addr
         self.protocol: Optional[TCPClientProtocol] = None
 
     @property
@@ -72,6 +74,12 @@ class TcpClient(BaseTcpStateful, ABC):
             ),
             timeout=self.timeout,
         )
+
+    def set_socket_options(self, sock: socket.socket):
+        super().set_socket_options(sock)
+
+        if self.reuse_addr:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
 
 class TcpV4Client(TcpClient, IP4Mixin): ...

--- a/t/func/framework/asyn/tcp_server.py
+++ b/t/func/framework/asyn/tcp_server.py
@@ -129,15 +129,19 @@ class TcpServer(BaseTcpStateful, ABC):
 
         await self.server.start_serving()
 
+    def close_client_with_rst(self, transport) -> None:
+        client_socket = transport.get_extra_info("socket")
+        linger = struct.pack("ii", 1, 0)
+        client_socket.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, linger)
+        transport.abort()
+        self.logger.debug(f"closed {client_socket} with rst")
+
     def close_all_clients_sockets(self):
         for transport in self.transports:
             if transport.is_closing():
                 continue
 
-            client_socket = transport.get_extra_info("socket")
-            client_socket.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
-            transport.abort()
-            self.logger.debug(f"closed {client_socket}")
+            self.close_client_with_rst(transport)
 
         self.logger.debug(f"closed {len(self.transports)} transports")
 

--- a/t/func/framework/stateful.py
+++ b/t/func/framework/stateful.py
@@ -462,7 +462,14 @@ class SocketBaseNetworkStateful(NetworkStateful, abc.ABC):
 
     async def check_socket_closed(self, repeat=0, interval=0.1, retry=50):
         if self.socket_type == socket.SOCK_STREAM:
-            cmd = "ss -tan"
+            formatted_ip = self.ip_format(self.ip)
+            formatted_remote_ip = self.ip_format(self.remote_ip)
+
+            cmd = (
+                f"ss -tan "
+                f'| grep "{formatted_ip}:{self.port}" '
+                f'| grep "{formatted_remote_ip}:{self.remote_port}"'
+            )
         elif self.socket_type == socket.SOCK_DGRAM:
             cmd = "ss -uan"
         elif self.socket_type == socket.SOCK_RAW:

--- a/t/func/tests/fixtures/clonners.py
+++ b/t/func/tests/fixtures/clonners.py
@@ -44,7 +44,13 @@ async def server_cloner() -> ClonerCallable:
 
     yield wrapper
 
-    await asyncio.gather(*[clone.stop() for clone in _clones], return_exceptions=True)
+    # Stop clones sequentially because Netns serializes namespace access with
+    # an asyncio.Lock. Concurrent stop() calls may bind that lock to the current
+    # event loop, while subsequent pytest-asyncio fixture finalizers can run in
+    # another loop, causing "Lock is bound to a different event loop" errors.
+    for clone in _clones:
+        await clone.stop()
+
     _clones.clear()
 
 
@@ -72,12 +78,19 @@ async def client_cloner(server_cloner) -> ClonerCallable:
     _clones: list[RegularKernelSocketNetworkStateful] = []
 
     def wrapper(
-        cloner: RegularKernelSocketNetworkStateful, amount: int, fabric: Optional[Any] = None
+        cloner: RegularKernelSocketNetworkStateful,
+        amount: int,
+        fabric: Optional[Any] = None,
+        reuse_endpoint: bool = False,
     ) -> list[RegularKernelSocketNetworkStateful]:
         nonlocal _clones
 
-        ports = cloner.generate_new_ports(amount)
-        addresses = cloner.generate_new_addresses(amount)
+        if not reuse_endpoint:
+            ports = cloner.generate_new_ports(amount)
+            addresses = cloner.generate_new_addresses(amount)
+        else:
+            ports = [cloner.port] * amount
+            addresses = [cloner.ip] * amount
 
         class_to_create = fabric if fabric else cloner.__class__
 
@@ -96,11 +109,17 @@ async def client_cloner(server_cloner) -> ClonerCallable:
                     namespace=cloner.namespace,
                     testing_model=cloner.testing_model,
                     timeout=cloner.timeout,
+                    reuse_addr=reuse_endpoint,
                 )
             )
         return _clones
 
     yield wrapper
 
-    await asyncio.gather(*[clone.stop() for clone in _clones], return_exceptions=True)
+    # Stop clones sequentially because Netns serializes namespace access with
+    # an asyncio.Lock. Concurrent stop() calls may bind that lock to the current
+    # event loop, while subsequent pytest-asyncio fixture finalizers can run in
+    # another loop, causing "Lock is bound to a different event loop" errors.
+    for clone in _clones:
+        await clone.stop()
     _clones.clear()

--- a/t/func/tests/test_tcp_auth_filter.py
+++ b/t/func/tests/test_tcp_auth_filter.py
@@ -2,12 +2,15 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 import asyncio
+import socket
 
 import pytest
 from scapy.layers.inet import TCP
 
+from config import ConfigSettings
 from framework.asyn import TcpClient, TcpRawClient, TcpRawServer, TcpServer
 from framework.cmp import check_connection
+from framework.fabrics import client_fabric, server_fabric
 from framework.xfw import XFW
 
 
@@ -225,3 +228,126 @@ async def test_allow_tcp_flood_after_connection(
     assert (
         await tcp_raw_server.receive_tcp_flags() == tcp_flag
     ), f"TCP packet with {tcp_flag} with session is not allowed"
+
+
+@pytest.mark.only_in_gate_mode
+async def test_reset_one_connection_does_not_break_another(
+    xfw: XFW,
+    tcp_server: TcpServer,
+    tcp_client: TcpClient,
+    client_cloner,
+):
+    """
+    Resetting one authenticated TCP connection must not remove the
+    authentication state of another connection to the same server endpoint.
+    """
+    await xfw.rules_set("xfw { tcp_auth_filter; }")
+
+    tcp_server.echo_mode = True
+    await tcp_server.start()
+
+    #
+    # In gate mode xFW is placed between the clients and the server:
+    #
+    #   client1_ip:port1 -> xFW -> server_ip:port
+    #   client2_ip:port2 -> xFW -> server_ip:port
+    #
+    # Both connections share the same server endpoint but have different
+    # client addresses and ports.
+    #
+    clients = client_cloner(
+        cloner=tcp_client,
+        amount=2,
+    )
+    for client in clients:
+        await client.start()
+
+    first_client, second_client = clients
+
+    assert first_client.ip != second_client.ip
+    assert first_client.port != second_client.port
+
+    assert first_client.remote_ip == second_client.remote_ip
+    assert first_client.remote_port == second_client.remote_port
+
+    # Establish and verify both independent TCP connections.
+    await first_client.ping_pong()
+    await second_client.ping_pong()
+
+    #
+    # In gate mode TC egress sees the original client-to-server
+    # packets. With the old endpoint-only TCP AUTH key, both
+    # connections were therefore represented by the same destination:
+    #
+    #   server_ip:port
+    #
+    # Resetting the first connection could remove this shared entry
+    # and break the second connection even though it was still valid.
+    #
+    first_server_transport = tcp_server.transports[0]
+    tcp_server.close_client_with_rst(first_server_transport)
+
+    await asyncio.sleep(0)
+
+    # Must use the already established second connection.
+    # No reconnect is allowed here.
+    await second_client.ping_pong()
+
+
+async def test_reset_one_connection_does_not_break_another_reuse_addr(
+    xfw: XFW, tcp_server: TcpServer, tcp_client: TcpClient, client_cloner, server_cloner
+):
+    """
+    Resetting one authenticated TCP connection must not remove the
+    authentication state of another connection with the same client
+    endpoint but a different server address.
+    """
+    await xfw.rules_set("xfw { tcp_auth_filter; }")
+
+    servers = server_cloner(cloner=tcp_server, amount=2)
+    for server in servers:
+        server.echo_mode = True
+        await server.start()
+
+    clients = client_cloner(cloner=tcp_client, amount=2, reuse_endpoint=True)
+    first_client, second_client = clients
+    first_server, second_server = servers
+
+    first_client.remote_ip = first_server.ip
+    first_client.remote_port = first_server.port
+
+    second_client.remote_ip = second_server.ip
+    second_client.remote_port = second_server.port
+
+    for client in clients:
+        await client.start()
+
+    assert first_client.ip == second_client.ip
+    assert first_client.port == second_client.port
+
+    assert first_client.remote_ip != second_client.remote_ip
+    assert first_client.remote_port != second_client.remote_port
+
+    # Establish and verify both independent TCP connections.
+    await first_client.ping_pong()
+    await second_client.ping_pong()
+
+    #
+    # Reset only the first connection.
+    #
+    # With the old endpoint-only TCP AUTH key, both connections had
+    # the same authentication key on the server-to-client path:
+    #
+    #   client_ip:port
+    #
+    # Therefore, resetting the first connection could remove the
+    # authentication state used by the second one.
+    #
+    first_client.use_rst_for_connection_closing()
+    first_client.transport.abort()
+
+    await asyncio.sleep(0)
+
+    # Must use the already established second connection.
+    # No reconnect is allowed here.
+    await second_client.ping_pong()


### PR DESCRIPTION
tcp_auth: track connections by full TCP 4-tuple

TCP AUTH previously used XfwSockAddr as the connection-tracking key.
The key contained only one IP address and one TCP port, so it identified
an endpoint rather than an individual TCP connection.

This was incorrect for connection tracking because multiple independent
connections can share the same endpoint.

For example, consider several concurrent TCP connections passing through
xFW to the same protected service:

    192.168.122.13:57488 -> 192.168.122.199:443
    192.168.122.13:57490 -> 192.168.122.199:443
    192.168.122.13:57656 -> 192.168.122.199:443

On the TC egress path, all of these connections were represented by the
same destination endpoint:

    192.168.122.199:443

The same endpoint was then used by XDP as the source key for packets
arriving in the reverse direction.

As a result, unrelated TCP connections shared the same authentication
state. This was especially harmful for RST and FIN processing. An RST
belonging to one connection could delete the common
192.168.122.199:443 entry, causing subsequent packets belonging to other
still valid connections to miss the authentication map and be dropped.

This was observed in tests creating many concurrent connections. For
example, after the state associated with

    192.168.122.199:443 -> 192.168.122.13:57488

was removed by an RST, a packet belonging to

    192.168.122.199:443 -> 192.168.122.13:57490

looked up the same old endpoint key and missed the authentication map.

Replace XfwSockAddr with XfwTcpConnKey containing the complete TCP
4-tuple:

    source IP
    destination IP
    source port
    destination port

XDP constructs the key in the current packet direction. TC egress
constructs the tuple in the reverse direction so that the entry it
creates matches the key that XDP will use when the reply packet arrives.

Thus, the two directions of a TCP connection remain represented by
directional entries, but each entry now identifies the complete TCP
flow instead of only one endpoint. Connections sharing the same server
endpoint therefore no longer share authentication state.

The connection key is populated during packet parsing and is also passed
to filters which need the source address for incident accounting. This
allows the old ilog_addr fields to be removed from XfwGlobalCtx and
XfwDnsCtx, avoiding an additional copy of the packet source address.
This also helps reduce BPF stack usage introduced by the larger
XfwTcpConnKey.

Use the complete tuple itself as the BPF map key instead of storing an
XXH64 fingerprint as done by TCP SYN drop.

The SYN-drop maps intentionally use compact 64-bit tuple fingerprints.
They operate as an attack-mitigation mechanism where an extremely rare
hash collision is an acceptable trade-off for smaller keys and cheaper
state under very high SYN rates.

TCP AUTH has different correctness and security requirements. A collision
in an externally computed 64-bit fingerprint would make two different
TCP connections indistinguishable to the BPF map. Depending on the
operation, this could cause one connection to authenticate, expire, or
delete the state of another connection.

BPF_MAP_TYPE_LRU_HASH already hashes its keys internally. When the full
4-tuple is used as the map key, an internal hash collision only places
different keys in the same hash bucket; the map still compares the full
keys and keeps the connections distinct. Pre-hashing the tuple to 64 bits
would discard that information before the BPF map sees the key and make
such collisions impossible to resolve.

Therefore TCP AUTH stores the full 4-tuple despite its larger key size,
while TCP SYN drop continues to use compact XXH64 fingerprints where
that trade-off is appropriate.

Also perform minor code-style cleanup in the affected code and wrap
several long lines to comply with the 80-column limit.